### PR TITLE
Fixed MCO typo: zero -> capital o

### DIFF
--- a/arm/stm32/setup_pll.adb
+++ b/arm/stm32/setup_pll.adb
@@ -262,10 +262,10 @@ procedure Setup_Pll is
                                   2 => To_APB (APB2_PRE))),
          RTCPRE  => 16#0#,
          I2SSRC  => I2S_Clock_Selection'Enum_Rep (I2SSEL_PLL),
-         MCO1    => MC01_Clock_Selection'Enum_Rep (MC01SEL_HSI),
-         MCO1PRE => MC0x_Prescaler'Enum_Rep (MC0xPRE_DIV1),
-         MCO2    => MC02_Clock_Selection'Enum_Rep (MC02SEL_SYSCLK),
-         MCO2PRE => MC0x_Prescaler'Enum_Rep (MC0xPRE_DIV5),
+         MCO1    => MCO1_Clock_Selection'Enum_Rep (MCO1SEL_HSI),
+         MCO1PRE => MCOx_Prescaler'Enum_Rep (MCOxPRE_DIV1),
+         MCO2    => MCO2_Clock_Selection'Enum_Rep (MCO2SEL_SYSCLK),
+         MCO2PRE => MCOx_Prescaler'Enum_Rep (MCOxPRE_DIV5),
          others  => <>);
 
       if Activate_PLL then

--- a/examples/stm32f4-discovery/leds-containers/src/stm32f4-reset_clock_control.ads
+++ b/examples/stm32f4-discovery/leds-containers/src/stm32f4-reset_clock_control.ads
@@ -148,17 +148,17 @@ package STM32F4.Reset_Clock_Control is
    PPRE2_DIV16    : constant Word := 16#E000#; -- APB2 is HCLK / 16
 
    --  MCO1 clock selector
-   MCO1SEL_HSI    : constant Word := 0 * 2**21; -- HSI clock on MC01 pin
-   MCO1SEL_LSE    : constant Word := 1 * 2**21; -- LSE clock on MC01 pin
-   MCO1SEL_HSE    : constant Word := 2 * 2**21; -- HSE clock on MC01 pin
-   MCO1SEL_PLL    : constant Word := 3 * 2**21; -- PLL clock on MC01 pin
+   MCO1SEL_HSI    : constant Word := 0 * 2**21; -- HSI clock on MCO1 pin
+   MCO1SEL_LSE    : constant Word := 1 * 2**21; -- LSE clock on MCO1 pin
+   MCO1SEL_HSE    : constant Word := 2 * 2**21; -- HSE clock on MCO1 pin
+   MCO1SEL_PLL    : constant Word := 3 * 2**21; -- PLL clock on MCO1 pin
 
    --  MCO1 prescaler
-   MCO1PRE_DIV1   : constant Word := 0 * 2**24; -- MC01 divides by 1
-   MCO1PRE_DIV2   : constant Word := 4 * 2**24; -- MC01 divides by 2
-   MCO1PRE_DIV3   : constant Word := 5 * 2**24; -- MC01 divides by 3
-   MCO1PRE_DIV4   : constant Word := 6 * 2**24; -- MC01 divides by 4
-   MCO1PRE_DIV5   : constant Word := 7 * 2**24; -- MC01 divides by 5
+   MCO1PRE_DIV1   : constant Word := 0 * 2**24; -- MCO1 divides by 1
+   MCO1PRE_DIV2   : constant Word := 4 * 2**24; -- MCO1 divides by 2
+   MCO1PRE_DIV3   : constant Word := 5 * 2**24; -- MCO1 divides by 3
+   MCO1PRE_DIV4   : constant Word := 6 * 2**24; -- MCO1 divides by 4
+   MCO1PRE_DIV5   : constant Word := 7 * 2**24; -- MCO1 divides by 5
 
    --  MCO2 clock selector
    MCO2SEL_SYSCLK : constant Word := 0 * 2**30; -- SYSCLK clock on MCO2 pin

--- a/src/s-stm32.ads
+++ b/src/s-stm32.ads
@@ -131,33 +131,33 @@ package System.STM32 is
       I2SSEL_CKIN)
      with Size => 1;
 
-   type MC01_Clock_Selection is
-     (MC01SEL_HSI,
-      MC01SEL_LSE,
-      MC01SEL_HSE,
-      MC01SEL_PLL)
+   type MCO1_Clock_Selection is
+     (MCO1SEL_HSI,
+      MCO1SEL_LSE,
+      MCO1SEL_HSE,
+      MCO1SEL_PLL)
      with Size => 2;
 
-   type MC02_Clock_Selection is
-     (MC02SEL_SYSCLK,
-      MC02SEL_PLLI2S,
-      MC02SEL_HSE,
-      MC02SEL_PLL)
+   type MCO2_Clock_Selection is
+     (MCO2SEL_SYSCLK,
+      MCO2SEL_PLLI2S,
+      MCO2SEL_HSE,
+      MCO2SEL_PLL)
      with Size => 2;
 
-   type MC0x_Prescaler is
-     (MC0xPRE_DIV1,
-      MC0xPRE_DIV2,
-      MC0xPRE_DIV3,
-      MC0xPRE_DIV4,
-      MC0xPRE_DIV5)
+   type MCOx_Prescaler is
+     (MCOxPRE_DIV1,
+      MCOxPRE_DIV2,
+      MCOxPRE_DIV3,
+      MCOxPRE_DIV4,
+      MCOxPRE_DIV5)
      with Size => 3;
-   for MC0x_Prescaler use
-     (MC0xPRE_DIV1 => 0,
-      MC0xPRE_DIV2 => 2#100#,
-      MC0xPRE_DIV3 => 2#101#,
-      MC0xPRE_DIV4 => 2#110#,
-      MC0xPRE_DIV5 => 2#111#);
+   for MCOx_Prescaler use
+     (MCOxPRE_DIV1 => 0,
+      MCOxPRE_DIV2 => 2#100#,
+      MCOxPRE_DIV3 => 2#101#,
+      MCOxPRE_DIV4 => 2#110#,
+      MCOxPRE_DIV5 => 2#111#);
 
    --  Constants for RCC CR register
 


### PR DESCRIPTION
There was a typo in some MCO definitions - a zero instead of capital "O"