### PR TITLE
Add support for runtime sources generated from template files.

### DIFF
--- a/arm/cortexm.py
+++ b/arm/cortexm.py
@@ -1,6 +1,7 @@
 # This module contains cortex-m bsp support
 from support.bsp_sources.archsupport import ArchSupport
 from support.bsp_sources.target import Target
+from support.files_holder import TemplateFileInstaller
 
 
 class CortexMArch(ArchSupport):
@@ -81,6 +82,24 @@ class ArmV7MTarget(ArmV6MTarget):
         return {'zfp': 'system-xi-arm.ads',
                 'ravenscar-sfp': 'system-xi-cortexm4-sfp.ads',
                 'ravenscar-full': 'system-xi-cortexm4-full.ads'}
+
+    @property
+    def system_ads_installer(self):
+        # The TemplateFileInstaller will replace instances of ${Max_Priority}
+        # from the source system.ads file with the desired value when
+        # copying system.ads into the runtime's source tree
+        installer = TemplateFileInstaller({
+            'Max_Priority':255 - self.interrupt_priorities + 1,
+            'Max_Interrupt_Priority':255
+        })
+        return {'zfp':installer,
+                'ravenscar-sfp':installer,
+                'ravenscar-full':installer}
+
+    @property
+    def interrupt_priorities(self):
+        # By default, assume 4-bit interrupt priorities.
+        return 16
 
     def __init__(self):
         super(ArmV7MTarget, self).__init__()

--- a/src/system/system-xi-cortexm4-full.ads
+++ b/src/system/system-xi-cortexm4-full.ads
@@ -110,14 +110,14 @@ package System is
 
    --  241 .. 255 corresponds to priority level 15 .. 1
 
-   Max_Interrupt_Priority   : constant Positive := 255;
-   Max_Priority             : constant Positive := 240;
+   Max_Interrupt_Priority   : constant Positive := ${Max_Interrupt_Priority};
+   Max_Priority             : constant Positive := ${Max_Priority};
 
-   subtype Any_Priority       is Integer range         0 .. 255;
-   subtype Priority           is Any_Priority range    0 .. 240;
-   subtype Interrupt_Priority is Any_Priority range  241 .. 255;
+   subtype Any_Priority       is Integer range         0 .. ${Max_Interrupt_Priority};
+   subtype Priority           is Any_Priority range    0 .. ${Max_Priority};
+   subtype Interrupt_Priority is Any_Priority range  ${Max_Priority} + 1 .. ${Max_Interrupt_Priority};
 
-   Default_Priority : constant Priority := 120;
+   Default_Priority : constant Priority := Max_Priority / 2;
 
 private
 

--- a/src/system/system-xi-cortexm4-sfp.ads
+++ b/src/system/system-xi-cortexm4-sfp.ads
@@ -120,14 +120,14 @@ package System is
 
    --  241 .. 255 corresponds to priority level 15 .. 1
 
-   Max_Interrupt_Priority   : constant Positive := 255;
-   Max_Priority             : constant Positive := 240;
+   Max_Interrupt_Priority   : constant Positive := ${Max_Interrupt_Priority};
+   Max_Priority             : constant Positive := ${Max_Priority};
 
-   subtype Any_Priority       is Integer range         0 .. 255;
-   subtype Priority           is Any_Priority range    0 .. 240;
-   subtype Interrupt_Priority is Any_Priority range  241 .. 255;
+   subtype Any_Priority       is Integer range         0 .. ${Max_Interrupt_Priority};
+   subtype Priority           is Any_Priority range    0 .. ${Max_Priority};
+   subtype Interrupt_Priority is Any_Priority range  ${Max_Priority} + 1 .. ${Max_Interrupt_Priority};
 
-   Default_Priority : constant Priority := 120;
+   Default_Priority : constant Priority := Max_Priority / 2;
 
 private
 

--- a/support/bsp_sources/archsupport.py
+++ b/support/bsp_sources/archsupport.py
@@ -1,7 +1,7 @@
 import copy
 import os
 
-from support.files_holder import FilesHolder
+from support.files_holder import FilesHolder, CopyFileInstaller
 
 
 class ArchSupport(FilesHolder):
@@ -81,8 +81,8 @@ class ArchSupport(FilesHolder):
         else:
             return self._parent.has_asm(dir)
 
-    def add_sources(self, dir, sources):
-        super(ArchSupport, self).add_sources(dir, sources)
+    def add_sources(self, dir, sources, installer=CopyFileInstaller()):
+        super(ArchSupport, self).add_sources(dir, sources, installer)
         if 'gnarl' in dir:
             if dir not in self.gnarl_dirs:
                 self.gnarl_dirs.append(dir)
@@ -153,9 +153,13 @@ class ArchSupport(FilesHolder):
 
             if not os.path.exists(destdir):
                 os.makedirs(destdir)
-            self._copy_pair(dst=val['name'], srcfile=val['pair'],
-                            destdir=destdir,
-                            installed_files=installed_files)
+            CopyFileInstaller().install_pair(
+                dst=val['name'],
+                srcfile=val['pair'],
+                destdir=destdir,
+                installed_files=installed_files,
+                target=self
+            )
             files.append(rel + '/' + val['name'])
 
     def install_libgnat(self, dest, dirs, installed_files):
@@ -186,7 +190,13 @@ class ArchSupport(FilesHolder):
             os.makedirs(destdir)
 
         for k, v in self.dirs[dirname].items():
-            self._copy_pair(dst=k, srcfile=v, destdir=destdir,
-                            installed_files=installed_files)
+            srcfile, installer = v
+            installer.install_pair(
+                dst=k,
+                srcfile=srcfile,
+                destdir=destdir,
+                installed_files=installed_files,
+                target=self
+            )
 
         return rel

--- a/support/bsp_sources/installer.py
+++ b/support/bsp_sources/installer.py
@@ -219,8 +219,14 @@ class Installer(object):
                 if not os.path.exists(full):
                     os.makedirs(full)
 
-                for srcname, pair in l.items():
-                    self.tgt._copy_pair(srcname, pair, full)
+                for srcname, (pair, installer) in l.items():
+                    installer.install_pair(
+                        dst=srcname,
+                        srcfile=pair,
+                        destdir=full,
+                        installed_files=None,
+                        target=self.tgt
+                    )
 
             # user-defined sources
             rts_gnat.append('user_srcs')

--- a/support/files_holder.py
+++ b/support/files_holder.py
@@ -1,9 +1,147 @@
 import os
+import re
 import shutil
 import sys
 
 from support import fullpath
 
+class CopyFileInstaller(object):
+    def install(self, src, dst, installed_files, target):
+        "Copy (or symlink) src to dst"
+
+        if not os.path.isfile(src):
+            print "runtime file " + src + " does not exists"
+            sys.exit(4)
+
+        already_exists = False
+
+        if os.path.isfile(dst):
+            with open(dst, 'r') as fp:
+                cnt1 = fp.read()
+            with open(src, 'r') as fp:
+                cnt2 = fp.read()
+            if cnt1 != cnt2:
+                print "runtime file " + dst + " already exists"
+                print "cannot install " + src
+                sys.exit(5)
+            else:
+                already_exists = True
+
+        if installed_files is not None:
+            if os.path.basename(dst) in installed_files:
+                print "runtime file " + dst + " installed multiple times"
+                sys.exit(6)
+
+            installed_files.append(os.path.basename(dst))
+
+        if already_exists:
+            if target.verbose:
+                print "same file, skip: " + src + ", " + dst
+        else:
+            if target.verbose:
+                print "copy " + src + " to " + dst
+            if target.link:
+                try:
+                    os.symlink(os.path.abspath(src), dst)
+                except os.error, e:
+                    print "symlink error for " + src
+                    print "msg: " + str(e)
+                    sys.exit(2)
+            else:
+                shutil.copy(src, dst)
+
+    def install_pair(self, dst, srcfile, destdir, installed_files, target):
+        "Copy after substitution with pairs"
+
+        dstdir = os.path.join(destdir, os.path.basename(dst))
+
+        # Find the sourcedir
+        if srcfile is None:
+            print "No source file for %s" % dst
+            sys.exit(2)
+
+        # Full path to the source file
+        src = None
+
+        if '/' not in srcfile:
+            # Files without path elements are in gnat
+            assert FilesHolder.manifest, "Error: MANIFEST file not found"
+            assert srcfile in FilesHolder.manifest, \
+                "Error: source file %s not in MANIFEST" % srcfile
+            src = os.path.join(self.gnatdir, srcfile)
+
+        elif srcfile.split('/')[0] in ('hie', 'libgnarl', 'libgnat'):
+            # BB-specific file in gnat/hie
+            src = os.path.join(self.gnatdir, srcfile)
+            assert os.path.exists(src), \
+                "Error: source file %s not found in gnat" % srcfile
+
+        else:
+            # Look into the current repository
+            src = fullpath(srcfile)
+
+            if not os.path.exists(src):
+                # Look into gcc
+                src = os.path.join(self.gccdir, srcfile)
+
+        if src is None or not os.path.exists(src):
+            print "Cannot find source dir for %s" % srcfile
+            sys.exit(2)
+            sys.exit(2)
+
+        self.install(src, dstdir, installed_files, target)
+
+class TemplateFileInstaller(CopyFileInstaller):
+    def __init__(self, vars):
+        self._vars = vars
+
+    def install(self, src, dst, installed_files, target):
+        "Copy src to dst, replacing instances of ${var} in src"
+
+        if not os.path.isfile(src):
+            print "runtime file " + src + " does not exists"
+            sys.exit(4)
+
+        already_exists = False
+
+        with open(src, 'r') as fp:
+            src_contents = fp.read()
+
+        # Replace all instances matching the format: ${var} with the
+        # corresponding value in self.vars, using "var" as the key.
+        # E.g. given: self.vars = {'key1', 'hello'}
+        # then all instances of "${key1}" in the source file are replaced
+        # with "hello" in the destination file.
+        # Variables in the ${var} format, but without a corresponding
+        # key in self.vars are replaced with an empty string.
+        def lookup(match):
+            return str(self._vars.get(match.group(1)))
+        contents = re.sub(r'\$\{([^\}]*)\}', lookup, src_contents)
+
+        if os.path.isfile(dst):
+            with open(dst, 'r') as fp:
+                dst_contents = fp.read()
+
+            if dst_contents != contents:
+                print "runtime file " + dst + " already exists"
+                print "cannot install " + src
+                sys.exit(5)
+            else:
+                already_exists = True
+
+        if installed_files is not None:
+            if os.path.basename(dst) in installed_files:
+                print "runtime file " + dst + " installed multiple times"
+                sys.exit(6)
+
+            installed_files.append(os.path.basename(dst))
+
+        if already_exists:
+            if target.verbose:
+                print "same file, skip: " + src + ", " + dst
+        else:
+            with open(dst, 'w') as fp:
+                fp.write(contents)
 
 class FilesHolder(object):
     # Sources directories
@@ -49,7 +187,7 @@ class FilesHolder(object):
                     if line and not line.startswith('--'):
                         FilesHolder.manifest.append(line)
 
-    def add_source(self, dir, dst, src):
+    def add_source(self, dir, dst, src, installer=CopyFileInstaller()):
         base = os.path.basename(dst)
         # A file could have `.` in its name. (eg: pikeos4.2-cert-app.c)
         _, ext = base.rsplit('.', 1)
@@ -58,7 +196,7 @@ class FilesHolder(object):
             # remove the variant part from the destination file name
             base, _ = base.split('__')
             base = "%s.%s" % (base, ext)
-        self.dirs[dir][base] = src
+        self.dirs[dir][base] = (src, installer)
         if dir not in self.c_srcs:
             if ext in ('c', 'h'):
                 self.c_srcs.append(dir)
@@ -69,15 +207,15 @@ class FilesHolder(object):
             if ext in ('S', 'inc'):
                 self.asm_cpp_srcs.append(dir)
 
-    def add_sources(self, dir, sources):
+    def add_sources(self, dir, sources, installer=CopyFileInstaller()):
         if dir not in self.dirs:
             self.dirs[dir] = {}
         if isinstance(sources, list):
             for src in sources:
-                self.add_sources(dir, src)
+                self.add_sources(dir, src, installer)
         elif isinstance(sources, dict):
             for k, v in sources.items():
-                self.add_source(dir, k, v)
+                self.add_source(dir, k, v, installer)
         else:
             self.add_source(dir, sources, sources)
 
@@ -98,11 +236,11 @@ class FilesHolder(object):
     def remove_pair(self, original):
         for d in self.dirs:
             if original in self.dirs[d]:
-                self.dirs[d][original] = original
+                self.dirs[d][original] = (original, None)
                 return True
         return False
 
-    def update_pair(self, dest, src):
+    def update_pair(self, dest, src, installer=CopyFileInstaller()):
         assert isinstance(dest, basestring), \
             "dest is not a string: %s (src is %s)" % (dest, src)
         assert src is None or isinstance(src, basestring), \
@@ -110,99 +248,15 @@ class FilesHolder(object):
 
         for d in self.dirs:
             if dest in self.dirs[d]:
-                self.dirs[d][dest] = src
+                self.dirs[d][dest] = (src, installer)
                 return True
         print 'update_pair: %s not found' % dest
         sys.exit(2)
         # no such file
         return False
 
-    def update_pairs(self, pairs):
+    def update_pairs(self, pairs, installer=CopyFileInstaller()):
         for k, v in pairs.items():
-            if not self.update_pair(k, v):
+            if not self.update_pair(k, v, installer):
                 print "in update_pairs: no such source: %s" % k
         return True
-
-    def _copy(self, src, dst, installed_files):
-        "Copy (or symlink) src to dst"
-
-        if not os.path.isfile(src):
-            print "runtime file " + src + " does not exists"
-            sys.exit(4)
-
-        already_exists = False
-
-        if os.path.isfile(dst):
-            with open(dst, 'r') as fp:
-                cnt1 = fp.read()
-            with open(src, 'r') as fp:
-                cnt2 = fp.read()
-            if cnt1 != cnt2:
-                print "runtime file " + dst + " already exists"
-                print "cannot install " + src
-                sys.exit(5)
-            else:
-                already_exists = True
-
-        if installed_files is not None:
-            if os.path.basename(dst) in installed_files:
-                print "runtime file " + dst + " installed multiple times"
-                sys.exit(6)
-
-            installed_files.append(os.path.basename(dst))
-
-        if already_exists:
-            if self.verbose:
-                print "same file, skip: " + src + ", " + dst
-        else:
-            if self.verbose:
-                print "copy " + src + " to " + dst
-            if self.link:
-                try:
-                    os.symlink(os.path.abspath(src), dst)
-                except os.error, e:
-                    print "symlink error for " + src
-                    print "msg: " + str(e)
-                    sys.exit(2)
-            else:
-                shutil.copy(src, dst)
-
-    def _copy_pair(self, dst, srcfile, destdir, installed_files=None):
-        "Copy after substitution with pairs"
-
-        dstdir = os.path.join(destdir, os.path.basename(dst))
-
-        # Find the sourcedir
-        if srcfile is None:
-            print "No source file for %s" % dst
-            sys.exit(2)
-
-        # Full path to the source file
-        src = None
-
-        if '/' not in srcfile:
-            # Files without path elements are in gnat
-            assert FilesHolder.manifest, "Error: MANIFEST file not found"
-            assert srcfile in FilesHolder.manifest, \
-                "Error: source file %s not in MANIFEST" % srcfile
-            src = os.path.join(self.gnatdir, srcfile)
-
-        elif srcfile.split('/')[0] in ('hie', 'libgnarl', 'libgnat'):
-            # BB-specific file in gnat/hie
-            src = os.path.join(self.gnatdir, srcfile)
-            assert os.path.exists(src), \
-                "Error: source file %s not found in gnat" % srcfile
-
-        else:
-            # Look into the current repository
-            src = fullpath(srcfile)
-
-            if not os.path.exists(src):
-                # Look into gcc
-                src = os.path.join(self.gccdir, srcfile)
-
-        if src is None or not os.path.exists(src):
-            print "Cannot find source dir for %s" % srcfile
-            sys.exit(2)
-
-        self._copy(src, dstdir, installed_files)

--- a/support/rts_sources/__init__.py
+++ b/support/rts_sources/__init__.py
@@ -421,6 +421,11 @@ class SourceTree(FilesHolder):
         if not os.path.exists(destdir):
             os.makedirs(destdir)
 
-        for k, v in self.dirs[dirname].items():
-            self._copy_pair(dst=k, srcfile=v, destdir=destdir,
-                            installed_files=installed_files)
+        for k, (srcfile, installer) in self.dirs[dirname].items():
+            installer.install_pair(
+                dst=k,
+                srcfile=srcfile,
+                destdir=destdir,
+                installed_files=installed_files,
+                target=self
+            )


### PR DESCRIPTION
This pull request is a proposal to add simple "code generation" capability to build_rts.py to solve the problem identified in #12 of customizing system.ads interrupt priorities for different ARM targets that support varying numbers of interrupt priorities.

Currently, when build_rts.py generates the source tree it simply copies (or symlinks) files from bb-runtimes and GCC/GNAT sources into the target source tree. This pull request adds a mechanism to perform simple string substitutions while copying certain files. This allows a common "template" file to be customised for each specific runtime where required. For example, a common system.ads template file for Cortex-M4 devices may be specialised with the correct number of interrupt priorities for the specific device.

When copying these "template" files, the script will search for instances matching the pattern `${var}`, and will replace all instances with a value matching the key called `var` from a dictionary. For example, `${Max_Interrupt_Priority}` in the template file may be replaced with `255` in the generated source.

## Example
The default behaviour is to retain the existing behaviour, i.e. simply copy (or symlink) files without modifying their content. "Template" files that require this new functionality to modify files during generation must be explicitly configured as such, along with what values to substitute. Here is an example (using the nRF51 target as an example):
```Python
        self.add_sources('crt0', [
            'src/s-bbarat.ads',
            'src/s-bbarat.adb',
            'arm/nordic/nrf51/svd/i-nrf51.ads',
            'arm/nordic/nrf51/svd/i-nrf51-clock.ads',
            'arm/nordic/nrf51/svd/i-nrf51-rtc.ads',
            'arm/nordic/nrf51/svd/i-nrf51-uart.ads',
            'arm/nordic/nrf51/svd/handler.S',
            'arm/nordic/nrf51/start-rom.S',
            'arm/nordic/nrf51/s-bbmcpa.ads'],
            installer=TemplateFileInstaller({
                'key1': 10,
                'key2':'hello'
            })
```

In the above example, all of the source files mentioned in the list will be copied, and all instances in those files of `${key1}` will be replaced with `10` and all instances of `${key2}` will be replaced with `hello` in the destination file. These substitutions __only__ affect the files in the list. Other files will be copied or symlinked as usual, unless they also specify their own installer.

Since system.ads files have their own `system_ads` property in the `Target` class, I added a new property `system_ads_installer` which returns the installer object that should be used to install the system.ads files in the source tree for each runtime. This property may be overridden to define alternative behaviours during generation of the source tree for system.ads. For example, I have updated `ArmV7MTarget` to make use of this to customise the interrupt priorities for Cortex-M4 targets.

## Cortex-M4 Interrupt Priorities
I have used this new mechanism to customise `Any_Priority`, `Priority`, and `Interrupt_Priority` in system.ads based on the actual number of hardware interrupt priorities available on the specific Cortex-M4 device. The files `src/system/system-xi-cortexm4-full.ads` and `src/system/system-xi-cortexm4-sfp.ads` have been updated to act as template files. They define `${Max_Priority}` and `${Max_Interrupt_Priority}` in places where those values are required. The appropriate values are determined in `system_ads_installer` in `cortexm.py` based on the number of interrupt priorities available on the target.

The specific target classes can simply override the `interrupt_priorities` property to return the actual number of interrupt priorities available on the specific target.

Here's an example of the generated system.ads file for the `stm32f4` target:
```Ada
   Max_Interrupt_Priority   : constant Positive := 255;
   Max_Priority             : constant Positive := 240;

   subtype Any_Priority       is Integer range         0 .. 255;
   subtype Priority           is Any_Priority range    0 .. 240;
   subtype Interrupt_Priority is Any_Priority range  240 + 1 .. 255;

   Default_Priority : constant Priority := Max_Priority / 2;
```

## Implementation
The main change to the build scripts is to associate an "installer" object with each source/destination pair managed by the existing `FilesHolder` class. This "installer" object is responsible for actually implementing the desired behaviour to generate the destination file from the source file. 

The default installer is the new `CopyFileInstaller` class which just implements the behaviour from `FilesHolder._copy` and `FilesHolder._copy_pair`, i.e. to simply copy or symlink the file with no modifications.

The alternative installer is the new `TemplateFileInstaller` which performs the string substitutions during the file copy.

## Extensibility
Fabien mentioned in #12 that we may need more code generation in bb-runtimes going forward. Keeping this in mind, I designed this new mechanism to support different installers that may implement different ways of generating files.

To implement a new custom installer, it is just necessary to 1) create a new installer class derived from `CopyFileInstaller`, then 2) override the `install` method with the desired behaviour. Then 3) this new class can then be set as the installer when calling `add_sources`, like in the example above where I used `TemplateFileInstaller`.
