### PR TITLE
SAMV71: Fix linker script for loading from ROM (flash).

### DIFF
--- a/arm/sam/common-ROM.ld
+++ b/arm/sam/common-ROM.ld
@@ -38,6 +38,7 @@
 
 /* This script replaces ld's default linker script, providing the
    appropriate memory map and output format. */
+INCLUDE memory-map.ld
 
 _DEFAULT_STACK_SIZE = 4*1024;
 


### PR DESCRIPTION
The linker script does not define memory map and therefore linking stage fails.
This pull request fixes the linker script by including the memory map file.