### PR TITLE
Remove duplicate a-textio source for nrf52 targets

### DIFF
--- a/arm/cortexm.py
+++ b/arm/cortexm.py
@@ -528,8 +528,7 @@ class NRF52840(NRF52):
             'arm/nordic/nrf52/nrf52840/svd/i-nrf52-uicr.ads',
             'arm/nordic/nrf52/nrf52840/svd/i-nrf52-nvmc.ads',
             'arm/nordic/nrf52/nrf52840/svd/i-nrf52-rtc.ads',
-            'arm/nordic/nrf52/nrf52840/svd/i-nrf52-temp.ads',
-            'src/s-textio__null.adb')
+            'arm/nordic/nrf52/nrf52840/svd/i-nrf52-temp.ads')
         self.add_gnarl_sources(
             'arm/nordic/nrf52/nrf52840/svd/handler.S',
             'arm/nordic/nrf52/nrf52840/svd/a-intnam.ads')
@@ -557,8 +556,7 @@ class NRF52832(NRF52):
             'arm/nordic/nrf52/nrf52832/svd/i-nrf52-uicr.ads',
             'arm/nordic/nrf52/nrf52832/svd/i-nrf52-nvmc.ads',
             'arm/nordic/nrf52/nrf52832/svd/i-nrf52-rtc.ads',
-            'arm/nordic/nrf52/nrf52832/svd/i-nrf52-temp.ads',
-            'src/s-textio__null.adb')
+            'arm/nordic/nrf52/nrf52832/svd/i-nrf52-temp.ads')
 
         self.add_gnarl_sources(
             'arm/nordic/nrf52/nrf52832/svd/handler.S',


### PR DESCRIPTION
This fixes a runtime installation failure for the nrf52832 and nrf52840 targets where a-textio.adb was added to the GNAT sources twice, resulting in an installation failure when installing the second instance since the target file already existed.