### PR TITLE
Add support for STM32F0xx devices (using templates)

### DIFF
--- a/arm/cortexm.py
+++ b/arm/cortexm.py
@@ -4,6 +4,7 @@ from support.bsp_sources.target import Target
 
 import re
 
+
 class CortexMArch(ArchSupport):
     @property
     def name(self):
@@ -358,6 +359,7 @@ class CortexM0CommonArchSupport(ArmV6MTarget):
             'src/s-bbbosu__armv6m.adb',
             'src/s-bcpcst__pendsv.adb')
 
+
 class Stm32F0(CortexM0CommonArchSupport):
 
     # Flash memory size is determined by the "User code memory size"
@@ -373,7 +375,7 @@ class Stm32F0(CortexM0CommonArchSupport):
     # RAM size for STM32F03x is determined by the
     # device package (pin count) and user code memory size
     # (i.e. the last two characters of the device name, e.g. stm32f030f4)
-    f03x_ram_sizes = { # STM32F03xxx
+    f03x_ram_sizes = {  # STM32F03xxx
         'c4': 4,
         'c6': 4,
         'c8': 8,
@@ -457,7 +459,7 @@ class Stm32F0(CortexM0CommonArchSupport):
     @property
     def use_semihosting_io(self):
         return True
-    
+
     @property
     def loaders(self):
         return ('ROM', 'RAM')
@@ -468,14 +470,15 @@ class Stm32F0(CortexM0CommonArchSupport):
         # Determine MCU features from board name (e.g. 'stm32f071rb-hse')
         # The -hse or -hsi suffix specifies which clock source to
         # use for the runtime (either HSE or HSI)
-        m = re.match(r'.*f0([34579])([0128])([cefgkrv])([468bc])-(hsi|hse)', board)
+        m = re.match(r'.*f0([34579])([0128])([cefgkrv])([468bc])-(hsi|hse)',
+                     board)
         if m is None:
             raise RuntimeError("Unknown STM32F0 target: " + board)
-        sub_family_major      = m.group(1)
-        sub_family_minor      = m.group(2)
-        package               = m.group(3)
+        sub_family_major = m.group(1)
+        sub_family_minor = m.group(2)
+        package = m.group(3)
         user_code_memory_size = m.group(4)
-        clock_source          = m.group(5)
+        clock_source = m.group(5)
 
         self.board = board
 
@@ -483,11 +486,11 @@ class Stm32F0(CortexM0CommonArchSupport):
         if sub_family_major == '3':
             ram_size = self.f03x_ram_sizes[package + user_code_memory_size]
         elif sub_family_major in '45':
-            ram_size = 4 # All STM32F04x/STM32F05x devices have 4K RAM
+            ram_size = 4  # All STM32F04x/STM32F05x devices have 4K RAM
         elif sub_family_major == '7':
             ram_size = self.f07x_ram_sizes[package + user_code_memory_size]
         else:
-            ram_size = 32 # All STM32F09x devices have 32k RAM
+            ram_size = 32  # All STM32F09x devices have 32k RAM
 
         flash_size = self.flash_sizes[user_code_memory_size]
 
@@ -518,9 +521,12 @@ class Stm32F0(CortexM0CommonArchSupport):
             'arm/stm32/stm32f0xx/setup_pll.adb',
             'arm/stm32/stm32f0xx/s-bbmcpa.ads.tmpl',
             'arm/stm32/stm32f0xx/s-bbbopa.ads.tmpl',
-            'arm/stm32/stm32f0xx/stm32f0x{}/svd/i-stm32.ads'.format(sub_family_minor),
-            'arm/stm32/stm32f0xx/stm32f0x{}/svd/i-stm32-flash.ads'.format(sub_family_minor),
-            'arm/stm32/stm32f0xx/stm32f0x{}/svd/i-stm32-rcc.ads'.format(sub_family_minor))
+            ('arm/stm32/stm32f0xx/stm32f0x{}'
+             '/svd/i-stm32.ads').format(sub_family_minor),
+            ('arm/stm32/stm32f0xx/stm32f0x{}'
+             '/svd/i-stm32-flash.ads').format(sub_family_minor),
+            ('arm/stm32/stm32f0xx/stm32f0x{}'
+             '/svd/i-stm32-rcc.ads').format(sub_family_minor))
 
         # Configure MCU parameters based on family.
         if sub_family_major in '479':
@@ -547,7 +553,9 @@ class Stm32F0(CortexM0CommonArchSupport):
 
         # Choose interrupt names based on family
         self.add_gnarl_sources(
-            'arm/stm32/stm32f0xx/stm32f0x{}/svd/a-intnam.ads'.format(sub_family_minor))
+            ('arm/stm32/stm32f0xx/stm32f0x{}/'
+             'svd/a-intnam.ads').format(sub_family_minor))
+
 
 class CortexM1CommonArchSupport(ArmV6MTarget):
     @property

--- a/arm/cortexm.py
+++ b/arm/cortexm.py
@@ -2,6 +2,7 @@
 from support.bsp_sources.archsupport import ArchSupport
 from support.bsp_sources.target import Target
 
+import re
 
 class CortexMArch(ArchSupport):
     @property
@@ -321,6 +322,232 @@ class SmartFusion2(ArmV7MTarget):
             'arm/smartfusion2/svd/a-intnam.ads',
             'src/s-bbpara__smartfusion2.ads')
 
+
+class CortexM0CommonArchSupport(ArmV6MTarget):
+    @property
+    def name(self):
+        return 'cortex-m0'
+
+    @property
+    def loaders(self):
+        return ('ROM', 'RAM')
+
+    @property
+    def compiler_switches(self):
+        # The required compiler switches
+        return ('-mlittle-endian', '-mthumb', '-msoft-float',
+                '-mcpu=cortex-m0')
+
+    @property
+    def has_fpu(self):
+        # We require floating point attributes as soft-float is supported
+        return True
+
+    @property
+    def system_ads(self):
+        return {'zfp': 'system-xi-arm.ads',
+                'ravenscar-sfp': 'system-xi-armv6m-sfp.ads',
+                'ravenscar-full': 'system-xi-armv6m-full.ads'}
+
+    def __init__(self):
+        super(CortexM0CommonArchSupport, self).__init__()
+
+        self.add_gnat_sources('src/s-bbpara__cortexm0.ads')
+
+        self.add_gnarl_sources(
+            'src/s-bbbosu__armv6m.adb',
+            'src/s-bcpcst__pendsv.adb')
+
+class Stm32F0(CortexM0CommonArchSupport):
+
+    # Flash memory size is determined by the "User code memory size"
+    # part of the device name
+    flash_sizes = {
+        '4': 16,
+        '6': 32,
+        '8': 64,
+        'b': 128,
+        'c': 256
+    }
+
+    # RAM size for STM32F03x is determined by the
+    # device package (pin count) and user code memory size
+    # (i.e. the last two characters of the device name, e.g. stm32f030f4)
+    f03x_ram_sizes = { # STM32F03xxx
+        'c4': 4,
+        'c6': 4,
+        'c8': 8,
+        'cc': 32,
+        'e6': 4,
+        'f4': 4,
+        'f6': 4,
+        'g4': 4,
+        'g6': 4,
+        'k4': 4,
+        'k6': 4,
+        'r8': 8,
+        'rc': 32,
+    }
+
+    # RAM size for STM32F07x is also determined by the
+    # device package (pin count) and user code memory size.
+    f07x_ram_sizes = {
+        'c6': 6,
+        'c8': 16,
+        'cb': 16,
+        'f6': 6,
+        'rb': 16,
+        'v8': 16,
+        'vb': 16,
+    }
+
+    # Board parameters (for s-bbmcpa.ads) when HSE is used.
+    # For now these are hard-coded. These could be calculated
+    # from a configurable HSE clock frequency in a future
+    # improvement.
+    board_parameters_hse = {
+        'STM32_Main_Clock_Frequency': '48_000_000',
+        'STM32_HSE_Clock_Frequency': '8_000_000',
+        'STM32_HSE_Bypass': 'False',
+        'STM32_LSI_Enabled': 'True',
+        'STM32_PLL_Src': 'System.STM32.PLL_SRC_HSE_PREDIV',
+        'STM32_SYSCLK_Src': 'System.STM32.SYSCLK_SRC_PLL',
+        'STM32_PREDIV': '1',
+        'STM32_PLLMUL_Value': '6',
+        'STM32_AHB_PRE': 'System.STM32.AHBPRE_DIV1',
+        'STM32_APB_PRE': 'System.STM32.APBPRE_DIV1'
+    }
+
+    # Board parameters (for s-bbmcpa.ads) when HSI is used.
+    # These parameters are suitable for the clock tree in
+    # F04x, F07x, and F09x devices.
+    board_parameters_hsi = {
+        'STM32_Main_Clock_Frequency': '48_000_000',
+        'STM32_HSE_Clock_Frequency': '8_000_000',
+        'STM32_HSE_Bypass': 'False',
+        'STM32_LSI_Enabled': 'True',
+        'STM32_PLL_Src': 'System.STM32.PLL_SRC_HSI_PREDIV',
+        'STM32_SYSCLK_Src': 'System.STM32.SYSCLK_SRC_PLL',
+        'STM32_PREDIV': '1',
+        'STM32_PLLMUL_Value': '6',
+        'STM32_AHB_PRE': 'System.STM32.AHBPRE_DIV1',
+        'STM32_APB_PRE': 'System.STM32.APBPRE_DIV1'
+    }
+
+    # Board parameters (for s-bbmcpa.ads) when HSI is used.
+    # These parameters are suitable for the clock tree in
+    # F03x and F05x devices (fixed /2 divider on HSI).
+    board_parameters_hsi2 = {
+        'STM32_Main_Clock_Frequency': '48_000_000',
+        'STM32_HSE_Clock_Frequency': '8_000_000',
+        'STM32_HSE_Bypass': 'False',
+        'STM32_LSI_Enabled': 'True',
+        'STM32_PLL_Src': 'System.STM32.PLL_SRC_HSI_2',
+        'STM32_SYSCLK_Src': 'System.STM32.SYSCLK_SRC_PLL',
+        'STM32_PREDIV': '1',
+        'STM32_PLLMUL_Value': '12',
+        'STM32_AHB_PRE': 'System.STM32.AHBPRE_DIV1',
+        'STM32_APB_PRE': 'System.STM32.APBPRE_DIV1'
+    }
+
+    @property
+    def name(self):
+        return self.board
+
+    @property
+    def use_semihosting_io(self):
+        return True
+    
+    @property
+    def loaders(self):
+        return ('ROM', 'RAM')
+
+    def __init__(self, board):
+        super(Stm32F0, self).__init__()
+
+        # Determine MCU features from board name (e.g. 'stm32f071rb-hse')
+        # The -hse or -hsi suffix specifies which clock source to
+        # use for the runtime (either HSE or HSI)
+        m = re.match(r'.*f0([34579])([0128])([cefgkrv])([468bc])-(hsi|hse)', board)
+        if m is None:
+            raise RuntimeError("Unknown STM32F0 target: " + board)
+        sub_family_major      = m.group(1)
+        sub_family_minor      = m.group(2)
+        package               = m.group(3)
+        user_code_memory_size = m.group(4)
+        clock_source          = m.group(5)
+
+        self.board = board
+
+        # Determine RAM size from sub-family, package, and user code mem. size
+        if sub_family_major == '3':
+            ram_size = self.f03x_ram_sizes[package + user_code_memory_size]
+        elif sub_family_major in '45':
+            ram_size = 4 # All STM32F04x/STM32F05x devices have 4K RAM
+        elif sub_family_major == '7':
+            ram_size = self.f07x_ram_sizes[package + user_code_memory_size]
+        else:
+            ram_size = 32 # All STM32F09x devices have 32k RAM
+
+        flash_size = self.flash_sizes[user_code_memory_size]
+
+        self.add_linker_script('arm/stm32/stm32f0xx/common-RAM.ld',
+                               loader='RAM')
+        self.add_linker_script('arm/stm32/stm32f0xx/common-ROM.ld',
+                               loader='ROM')
+
+        # Select memory map based on available memory size
+        # of the specific device
+        self.add_linker_script('arm/stm32/stm32f0xx/memory-map.ld.tmpl')
+
+        # Set template variables required by linker script
+        self.add_template_config_value(
+            'STM32_Linker_Flash_Size',
+            '{}K'.format(flash_size))
+        self.add_template_config_value(
+            'STM32_Linker_RAM_Size',
+            '{}K'.format(ram_size))
+
+        # Common source files
+        self.add_gnat_sources(
+            'arm/stm32/stm32f0xx/s-stm32.ads',
+            'arm/stm32/stm32f0xx/s-stm32.adb',
+            'arm/stm32/stm32f0xx/start-rom.S',
+            'arm/stm32/stm32f0xx/start-ram.S',
+            'arm/stm32/stm32f0xx/setup_pll.ads',
+            'arm/stm32/stm32f0xx/setup_pll.adb',
+            'arm/stm32/stm32f0xx/s-bbmcpa.ads.tmpl',
+            'arm/stm32/stm32f0xx/s-bbbopa.ads.tmpl',
+            'arm/stm32/stm32f0xx/stm32f0x{}/svd/i-stm32.ads'.format(sub_family_minor),
+            'arm/stm32/stm32f0xx/stm32f0x{}/svd/i-stm32-flash.ads'.format(sub_family_minor),
+            'arm/stm32/stm32f0xx/stm32f0x{}/svd/i-stm32-rcc.ads'.format(sub_family_minor))
+
+        # Configure MCU parameters based on family.
+        if sub_family_major in '479':
+            self.add_template_config_value('STM32_Simple_Clock_Tree', 'False')
+        else:
+            self.add_template_config_value('STM32_Simple_Clock_Tree', 'True')
+
+        # Configure board parameters based on chosen clock source (HSE or HSI)
+        # and the device family.
+        if clock_source == 'hse':
+            for key, value in self.board_parameters_hse.items():
+                self.add_template_config_value(key, value)
+
+        elif sub_family_major in '479':
+            # STM32F04x/STM32F07x/STM32F09x can use HSI directly
+            # as PLL input.
+            for key, value in self.board_parameters_hsi.items():
+                self.add_template_config_value(key, value)
+
+        else:
+            # STM32F03x/STM32F05x are forced to HSI/2 as PLL input.
+            for key, value in self.board_parameters_hsi2.items():
+                self.add_template_config_value(key, value)
+
+        # Choose interrupt names based on family
+        self.add_gnarl_sources(
+            'arm/stm32/stm32f0xx/stm32f0x{}/svd/a-intnam.ads'.format(sub_family_minor))
 
 class CortexM1CommonArchSupport(ArmV6MTarget):
     @property

--- a/arm/stm32/stm32f0xx/README
+++ b/arm/stm32/stm32f0xx/README
@@ -1,0 +1,149 @@
+ARM STM32F0 Runtimes
+==================
+
+Runtimes Supported
+------------------
+
+* ZFP
+* Ravenscar-SFP
+* Ravenscar-Full
+
+Targets Supported
+-----------------
+
+STM32F0xx MCUs (ARM Cortex-M0)
+
+System Clocks
+-------------
+
+Clocks Configuration
+,,,,,,,,,,,,,,,,,,,,
+
+The system clock source is the main phase-locked loop (PLL) driven by an
+external crystal. The clock tree parameters (e.g. HSI/HSE clock source,
+dividers and multipliers) are specified in package System.BB.Board_Parameters
+(in the gnat directory as file s-bbbopa.ads), as is the resulting main
+clock frequency. For example:
+
+.. code-block:: ada
+
+   Main_Clock_Frequency : constant               := 48_000_000;
+   HSE_Clock_Frequency  : constant               := 8_000_000;
+   HSE_Enabled          : constant Boolean       := True;
+   HSE_Bypass           : constant Boolean       := False;
+   LSI_Enabled          : constant Boolean       := True;
+   PLL_Src              : constant PLL_Source    := PLL_SRC_HSE_PREDIV;
+   SYSCLK_Src           : constant SYSCLK_Source := SYSCLK_SRC_PLL;
+   PREDIV               : constant PREDIV_Range  := 1;
+   PLLMUL_Value         : constant               := 6;
+   AHB_PRE              : constant AHB_Prescaler := AHBPRE_DIV1;
+   APB_PRE              : constant APB_Prescaler := APBPRE_DIV1;
+
+Change the values in that package to reflect your specific board, as
+necessary. The runtime system uses them to configure the blocks so
+changes will take effect automatically. Package System.BB.Parameters
+(gnat/s-bbpara.ads) imports those values and re-exports them as constants
+used by library procedure Setup_PLL. The shared procedure Setup_PLL
+configures the PLL and the derived clocks to achieve that main clock
+frequency. Compilation will fail if the requested clock frequency is not
+achievable.
+
+Startup Code
+------------
+
+The startup code is in multiple assembly language files located in the gnat
+subdirectory within the runtime.
+
+There are two assembly language files for the startup code, one each for
+executing from RAM or ROM. These are files named start-ram.S, start-rom.S
+respectively.
+
+The specific startup code is selected by the linker scripts' references to
+the unique symbols defined in the assembly files, via the entry point
+definitions.
+
+The start-\*.S files are used to define the interrupt vector table
+for both ZFP and Ravenscar runtimes. These files will need to be
+modified to use custom user interrupt handlers on ZFP profiles.
+For Ravenscar runtimes, user interrupt handlers are set up using the
+Attach_Handler aspect on protected procedures.
+
+Floating-point Co-processor
+---------------------------
+
+The Cortex-M0 does not have a hardware FPU. All floating-point calculations
+are performed in software.
+
+Interrupts
+----------
+
+The package Ada.Interrupts.Names (a-intnam.ads) is located in the gnat
+directory. This package spec was automatically generated from an SVD file so
+you will not need to change it unless an SVD file was unavailable for your
+target.
+
+See package System.BB.MCU_Parameters (s-bbmcpa.ads) for the number of
+interrupts defined. That number must reflect the contents of the
+SVD-generated package Ada.Interrupts.Names.
+
+Interrupt priorities
+,,,,,,,,,,,,,,,,,,,,
+
+The Ravenscar runtimes for the STM32F0 family only support a single
+interrupt priority level (because the BASEPRI register used for
+implementing interrupt priorities is is not implemented in the
+Cortex-M0 CPU).
+
+Memory Layout
+-------------
+
+The memory layout is controlled by linker scripts specific to whether the
+program is located in RAM or ROM. The scripts are located in the ld
+directory and are named common-RAM.ld and common-ROM.ld, respectively.
+
+Script selection is controlled by a scenario variable declared in an XML
+file named runtime.xml that is located in the runtime root directory. The
+scenario variable is used to specify linker switches.
+
+The memory sections' locations and sizes are specified in memory-map.ld,
+also located in the ld directory. The XML also specifies this file as part
+of the linker switches.
+
+You can modify all of these scripts as required. Alternatively, these
+scripts can be overridden at link time using the LDSCRIPT environment
+variable.
+
+Default stack sizes
+,,,,,,,,,,,,,,,,,,,
+
+The default main stack size is 2 KB
+The default interrupt stack size is 1 KB
+The default secondary stack size is 128 B
+
+The main stack size can be configured in the linker scripts: common-ROM/RAM.ld
+The interrupt and secondary stack sizes can be configured in s-bbpara.ads
+
+Resources Used
+--------------
+
+The Ravenscar runtime libraries use the SysTick interrupt to implement Ada
+semantics for time, i.e., delay statements and package Ada.Real_Time. The
+SysTick interrupt handler runs at highest priority. See procedure
+Sys_Tick_Handler in package body System.BB.CPU_Primitives
+(gnat/s-bbcppr.adb), which calls through to the handler in the trap vectors
+only when necessary for the sake of efficiency.
+
+Ada.Text_IO
+-----------
+
+The runtime libraries provide a minimal version of package Ada.Text_IO
+supporting character- and string-based input and output routines.
+
+IMPORTANT NOTE: By default the STM32F0 runtimes use a semihosting
+implementation of Ada.Text_IO, which is only functional when a
+debugger is attached. If Ada.Text_IO is used without a debugger
+attached then the CPU will HardFault or lockup when calls are
+made to Ada.Text_IO.
+
+If Ada.Text_IO is not used by the user application then the
+software will function both with and without a debugger attached.

--- a/arm/stm32/stm32f0xx/common-RAM.ld
+++ b/arm/stm32/stm32f0xx/common-RAM.ld
@@ -1,0 +1,142 @@
+/****************************************************************************
+ *                                                                          *
+ *                         GNAT COMPILER COMPONENTS                         *
+ *                                                                          *
+ *                                  A R M                                   *
+ *                                                                          *
+ *                            Linker Script File                            *
+ *                                                                          *
+ *      Copyright (C) 1999-2002 Universidad Politecnica de Madrid           *
+ *             Copyright (C) 2003-2006 The European Space Agency            *
+ *                   Copyright (C) 2003-2020 AdaCore                        *
+ *                                                                          *
+ * GNAT is free software;  you can  redistribute it  and/or modify it under *
+ * terms of the  GNU General Public License as published  by the Free Soft- *
+ * ware  Foundation;  either version 2,  or (at your option) any later ver- *
+ * sion.  GNAT is distributed in the hope that it will be useful, but WITH- *
+ * OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY *
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License *
+ * for  more details.  You should have  received  a copy of the GNU General *
+ * Public License  distributed with GNAT;  see file COPYING.  If not, write *
+ * to  the  Free Software Foundation,  51  Franklin  Street,  Fifth  Floor, *
+ * Boston, MA 02110-1301, USA.                                              *
+ *                                                                          *
+ * As a  special  exception,  if you  link  this file  with other  files to *
+ * produce an executable,  this file does not by itself cause the resulting *
+ * executable to be covered by the GNU General Public License. This except- *
+ * ion does not  however invalidate  any other reasons  why the  executable *
+ * file might be covered by the  GNU Public License.                        *
+ *                                                                          *
+ * GNARL was developed by the GNARL team at Florida State University.       *
+ * Extensive contributions were provided by Ada Core Technologies, Inc.     *
+ * The  executive  was developed  by the  Real-Time  Systems  Group  at the *
+ * Technical University of Madrid.                                          *
+ *                                                                          *
+ ****************************************************************************/
+
+/* This is a ARM specific version of this file */
+
+/* This script replaces ld's default linker script, providing the
+   appropriate memory map and output format. */
+
+INCLUDE memory-map.ld
+
+_DEFAULT_STACK_SIZE = 2*1024;
+
+ENTRY(_start_ram);
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP (*(.vectors))
+    *(.text .text.* .gnu.linkonce.t*)
+    *(.gnu.warning)
+  } > sram_tx
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > sram_ro
+  /* .ARM.exidx is 4-bytes aligned, so __exidx_start needs to be
+     aligned too. Note that assigning the location counter also makes
+     ld attach the following symbols to the next section (instead of the
+     previous section which is the default), so will properly
+     consider the location counter of .ARM.exidx for __exidx_start and
+      __exidx_end and not the previous section's one. */
+  . = ALIGN(0x4);
+  PROVIDE_HIDDEN (__exidx_start = .);
+  .ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } > sram_ro
+  PROVIDE_HIDDEN (__exidx_end = .);
+
+  .rodata :
+  {
+    *(.lit)
+    *(.rodata .rodata.* .gnu.linkonce.r*)
+    . = ALIGN(0x4);
+  } > sram_ro
+
+  .data :
+  {
+    __data_start = .;
+    *(.data .data.* .gnu.linkonce.d*)
+
+    /* Ensure that the end of the data section is always word aligned.
+       Initial values are stored in 4-bytes blocks so we must guarantee
+       that these blocks do not fall out the section (otherwise they are
+       truncated and the initial data for the last block are lost). */
+
+    . = ALIGN(0x4);
+    __data_end = .;
+  } > sram_da
+
+  .bss (NOLOAD): {
+   . = ALIGN(0x8);
+   __bss_start = .;
+
+   *(.bss .bss.*)
+   *(COMMON)
+
+   . = ALIGN(0x8);    /* Align the stack to 64 bits */
+   __bss_end = .;
+
+   __interrupt_stack_start = .;
+   *(.interrupt_stacks)
+   . = ALIGN(0x8);
+   __interrupt_stack_end = .;
+
+   __stack_start = .;
+   . += DEFINED (__stack_size) ? __stack_size : _DEFAULT_STACK_SIZE;
+   . = ALIGN(0x8);
+   __stack_end = .;
+
+   _end = .;
+   __heap_start = .;
+   __heap_end = ORIGIN(sram_bs) + LENGTH(sram_bs);
+  } > sram_bs
+
+  __bss_words = (__bss_end - __bss_start) >> 2;
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/arm/stm32/stm32f0xx/common-ROM.ld
+++ b/arm/stm32/stm32f0xx/common-ROM.ld
@@ -1,0 +1,145 @@
+/****************************************************************************
+ *                                                                          *
+ *                         GNAT COMPILER COMPONENTS                         *
+ *                                                                          *
+ *                                  A R M                                   *
+ *                                                                          *
+ *                            Linker Script File                            *
+ *                                                                          *
+ *      Copyright (C) 1999-2002 Universidad Politecnica de Madrid           *
+ *             Copyright (C) 2003-2006 The European Space Agency            *
+ *                   Copyright (C) 2003-2020 AdaCore                        *
+ *                                                                          *
+ * GNAT is free software;  you can  redistribute it  and/or modify it under *
+ * terms of the  GNU General Public License as published  by the Free Soft- *
+ * ware  Foundation;  either version 2,  or (at your option) any later ver- *
+ * sion.  GNAT is distributed in the hope that it will be useful, but WITH- *
+ * OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY *
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License *
+ * for  more details.  You should have  received  a copy of the GNU General *
+ * Public License  distributed with GNAT;  see file COPYING.  If not, write *
+ * to  the  Free Software Foundation,  51  Franklin  Street,  Fifth  Floor, *
+ * Boston, MA 02110-1301, USA.                                              *
+ *                                                                          *
+ * As a  special  exception,  if you  link  this file  with other  files to *
+ * produce an executable,  this file does not by itself cause the resulting *
+ * executable to be covered by the GNU General Public License. This except- *
+ * ion does not  however invalidate  any other reasons  why the  executable *
+ * file might be covered by the  GNU Public License.                        *
+ *                                                                          *
+ * GNARL was developed by the GNARL team at Florida State University.       *
+ * Extensive contributions were provided by Ada Core Technologies, Inc.     *
+ * The  executive  was developed  by the  Real-Time  Systems  Group  at the *
+ * Technical University of Madrid.                                          *
+ *                                                                          *
+ ****************************************************************************/
+
+/* This is a ARM specific version of this file */
+
+/* This script replaces ld's default linker script, providing the
+   appropriate memory map and output format. */
+
+INCLUDE memory-map.ld
+
+_DEFAULT_STACK_SIZE = 2*1024;
+
+ENTRY(_start_rom);
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP (*(.vectors))
+    *(.text .text.* .gnu.linkonce.t*)
+    *(.gnu.warning)
+  } > flash
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > flash
+  /* .ARM.exidx is 4-bytes aligned, so __exidx_start needs to be
+     aligned too. Note that assigning the location counter also makes
+     ld attach the following symbols to the next section (instead of the
+     previous section which is the default), so will properly
+     consider the location counter of .ARM.exidx for __exidx_start and
+      __exidx_end and not the previous section's one. */
+  . = ALIGN(0x4);
+  PROVIDE_HIDDEN (__exidx_start = .);
+  .ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } > flash
+  PROVIDE_HIDDEN (__exidx_end = .);
+
+  .rodata :
+  {
+    *(.lit)
+    *(.rodata .rodata.* .gnu.linkonce.r*)
+    . = ALIGN(0x4);
+    __rom_end = .;
+  } > flash
+
+  __data_load = __rom_end;
+  .data : AT (__data_load)
+  {
+    __data_start = .;
+    *(.data .data.* .gnu.linkonce.d*)
+
+    /* Ensure that the end of the data section is always word aligned.
+       Initial values are stored in 4-bytes blocks so we must guarantee
+       that these blocks do not fall out the section (otherwise they are
+       truncated and the initial data for the last block are lost). */
+
+    . = ALIGN(0x4);
+    __data_end = .;
+  } > sram_da
+  __data_words = (__data_end - __data_start) >> 2;
+
+  .bss (NOLOAD): {
+   . = ALIGN(0x8);
+   __bss_start = .;
+
+   *(.bss .bss.*)
+   *(COMMON)
+
+   . = ALIGN(0x8);    /* Align the stack to 64 bits */
+   __bss_end = .;
+
+   __interrupt_stack_start = .;
+   *(.interrupt_stacks)
+   . = ALIGN(0x8);
+   __interrupt_stack_end = .;
+
+   __stack_start = .;
+   . += DEFINED (__stack_size) ? __stack_size : _DEFAULT_STACK_SIZE;
+   . = ALIGN(0x8);
+   __stack_end = .;
+
+   _end = .;
+   __heap_start = .;
+   __heap_end = ORIGIN(sram_bs) + LENGTH(sram_bs);
+  } > sram_bs
+
+  __bss_words = (__bss_end - __bss_start) >> 2;
+
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
+}

--- a/arm/stm32/stm32f0xx/memory-map.ld.tmpl
+++ b/arm/stm32/stm32f0xx/memory-map.ld.tmpl
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *                                                                          *
+ *                         GNAT COMPILER COMPONENTS                         *
+ *                                                                          *
+ *                                  A R M                                   *
+ *                                                                          *
+ *                            Linker Script File                            *
+ *                                                                          *
+ *      Copyright (C) 1999-2002 Universidad Politecnica de Madrid           *
+ *             Copyright (C) 2003-2006 The European Space Agency            *
+ *                   Copyright (C) 2003-2020 AdaCore                        *
+ *                                                                          *
+ * GNAT is free software;  you can  redistribute it  and/or modify it under *
+ * terms of the  GNU General Public License as published  by the Free Soft- *
+ * ware  Foundation;  either version 2,  or (at your option) any later ver- *
+ * sion.  GNAT is distributed in the hope that it will be useful, but WITH- *
+ * OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY *
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License *
+ * for  more details.  You should have  received  a copy of the GNU General *
+ * Public License  distributed with GNAT;  see file COPYING.  If not, write *
+ * to  the  Free Software Foundation,  51  Franklin  Street,  Fifth  Floor, *
+ * Boston, MA 02110-1301, USA.                                              *
+ *                                                                          *
+ * As a  special  exception,  if you  link  this file  with other  files to *
+ * produce an executable,  this file does not by itself cause the resulting *
+ * executable to be covered by the GNU General Public License. This except- *
+ * ion does not  however invalidate  any other reasons  why the  executable *
+ * file might be covered by the  GNU Public License.                        *
+ *                                                                          *
+ * GNARL was developed by the GNARL team at Florida State University.       *
+ * Extensive contributions were provided by Ada Core Technologies, Inc.     *
+ * The  executive  was developed  by the  Real-Time  Systems  Group  at the *
+ * Technical University of Madrid.                                          *
+ *                                                                          *
+ ****************************************************************************/
+
+MEMORY
+{
+  flash  (rx) : ORIGIN = 0x08000000, LENGTH = "${STM32_Linker_Flash_Size}"
+  sram  (rwx) : ORIGIN = 0x20000000, LENGTH = "${STM32_Linker_RAM_Size}"
+}
+
+REGION_ALIAS("sram_tx", sram)
+REGION_ALIAS("sram_ro", sram)
+REGION_ALIAS("sram_bs", sram)
+REGION_ALIAS("sram_da", sram)

--- a/arm/stm32/stm32f0xx/s-bbbopa.ads.tmpl
+++ b/arm/stm32/stm32f0xx/s-bbbopa.ads.tmpl
@@ -1,0 +1,86 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                  GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                --
+--                                                                          --
+--            S Y S T E M . B B . B O A R D _ P A R A M E T E R S           --
+--                                                                          --
+--                                  S p e c                                 --
+--                                                                          --
+--                   Copyright (C) 2016-2020, AdaCore                       --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+-- The port of GNARL to bare board targets was initially developed by the   --
+-- Real-Time Systems Group at the Technical University of Madrid.           --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package defines board parameters for a generic STM32F0xx
+--  board with an 8 MHz HSE cystal.
+
+with System.STM32;
+
+package System.BB.Board_Parameters is
+   pragma No_Elaboration_Code_All;
+   pragma Preelaborate (System.BB.Board_Parameters);
+
+   --------------------
+   -- Hardware clock --
+   --------------------
+
+   --  If either of these values are changed then the clock configuration
+   --  below will also need to be changed (e.g. update PLLMUL_Value).
+
+   Main_Clock_Frequency : constant := "${STM32_Main_Clock_Frequency}";
+   --  Optimal frequency of the system clock.
+
+   HSE_Clock_Frequency : constant := "${STM32_HSE_Clock_Frequency}";
+   --  Frequency of High Speed External clock.
+
+   --  If either of the above values are changed then the clock configuration
+   --  below will need to be updated to generate the requested clock freq.
+
+   -------------------------
+   -- Clock configuration --
+   -------------------------
+
+   HSE_Bypass  : constant Boolean := "${STM32_HSE_Bypass}";
+   LSI_Enabled : constant Boolean := "${STM32_LSI_Enabled}";
+
+   --  Selection of clock sources
+
+   PLL_Src    : constant System.STM32.PLL_Source    :=
+     "${STM32_PLL_Src}";
+
+   SYSCLK_Src : constant System.STM32.SYSCLK_Source :=
+     "${STM32_SYSCLK_Src}";
+
+   --  Configure derived clocks
+
+   PREDIV       : constant System.STM32.PREDIV_Range := "${STM32_PREDIV}";
+   PLLMUL_Value : constant                           := "${STM32_PLLMUL_Value}";
+
+   AHB_PRE : constant System.STM32.AHB_Prescaler :=
+     "${STM32_AHB_PRE}";
+
+   APB_PRE : constant System.STM32.APB_Prescaler :=
+     "${STM32_APB_PRE}";
+
+end System.BB.Board_Parameters;

--- a/arm/stm32/stm32f0xx/s-bbmcpa.ads.tmpl
+++ b/arm/stm32/stm32f0xx/s-bbmcpa.ads.tmpl
@@ -1,0 +1,53 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                  GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                --
+--                                                                          --
+--              S Y S T E M . B B . M C U _ P A R A M E T E R S             --
+--                                                                          --
+--                                  S p e c                                 --
+--                                                                          --
+--                   Copyright (C) 2016-2020, AdaCore                       --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+-- The port of GNARL to bare board targets was initially developed by the   --
+-- Real-Time Systems Group at the Technical University of Madrid.           --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package defines MCU parameters for the STM32F04x, STM32F07x, and
+--  STM32F09x family of devices.
+
+package System.BB.MCU_Parameters is
+   pragma No_Elaboration_Code_All;
+   pragma Preelaborate;
+
+   Number_Of_Interrupts : constant := 32;
+
+   Simple_Clock_Tree : constant Boolean := "${STM32_Simple_Clock_Tree}";
+   --  This is True for STM32F03x and STM32F05x devices which have a simpler
+   --  clock tree that has a forced /2 divider between the HSI and PLL input,
+   --  and does not have the HSI48 clock.
+   --
+   --  This is False for STM32F04x, STM32F07x, and STM32F09x devices which
+   --  do not have the forced /2 divider between the HSI and PLL, and have
+   --  the HSI48 clock.
+
+end System.BB.MCU_Parameters;

--- a/arm/stm32/stm32f0xx/s-stm32.adb
+++ b/arm/stm32/stm32f0xx/s-stm32.adb
@@ -1,0 +1,131 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--          Copyright (C) 2012-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Unchecked_Conversion;
+
+with System.BB.Board_Parameters;
+
+with Interfaces;            use Interfaces;
+with Interfaces.STM32;      use Interfaces.STM32;
+with Interfaces.STM32.RCC;  use Interfaces.STM32.RCC;
+
+package body System.STM32 is
+
+   package Param renames System.BB.Board_Parameters;
+
+   HPRE_Presc_Table : constant array (AHB_Prescaler_Enum) of UInt32 :=
+     (2, 4, 8, 16, 64, 128, 256, 512);
+
+   PPRE_Presc_Table : constant array (APB_Prescaler_Enum) of UInt32 :=
+     (2, 4, 8, 16);
+
+   -------------------
+   -- System_Clocks --
+   -------------------
+
+   function System_Clocks return RCC_System_Clocks
+   is
+      Source       : constant SYSCLK_Source :=
+                      SYSCLK_Source'Val (RCC_Periph.CFGR.SWS);
+      Result       : RCC_System_Clocks;
+
+   begin
+      case Source is
+
+         --  HSI as source
+
+         when SYSCLK_SRC_HSI =>
+            Result.SYSCLK := HSICLK;
+
+         --  HSE as source
+
+         when SYSCLK_SRC_HSE =>
+            Result.SYSCLK := Param.HSE_Clock_Frequency;
+
+         --  PLL as source
+
+         when SYSCLK_SRC_PLL =>
+            declare
+               PLLMUL : constant UInt32 :=
+                 UInt32 (RCC_Periph.CFGR.PLLMUL) + 2;
+
+               PREDIV : constant UInt32 :=
+                 UInt32 (RCC_Periph.CFGR2.PREDIV + 1);
+
+               PLLOUT : UInt32;
+
+            begin
+               case PLL_Source'Val (RCC_Periph.CFGR.PLLSRC) is
+                  when PLL_SRC_HSI_2 =>
+                     PLLOUT := (HSICLK / 2) * PLLMUL;
+                  when PLL_SRC_HSI_PREDIV =>
+                     PLLOUT := (HSICLK / PREDIV) * PLLMUL;
+                  when PLL_SRC_HSE_PREDIV =>
+                     PLLOUT := (Param.HSE_Clock_Frequency / PREDIV) * PLLMUL;
+                  when PLL_SRC_HSI48_PREDIV =>
+                     PLLOUT := (HSI48CLK / PREDIV) * PLLMUL;
+               end case;
+
+               Result.SYSCLK := PLLOUT;
+            end;
+
+         --  HSI48 as source
+
+         when SYSCLK_SRC_HSI48 =>
+            Result.SYSCLK := HSI48CLK;
+      end case;
+
+      declare
+         function To_AHBP is new Ada.Unchecked_Conversion
+           (CFGR_HPRE_Field, AHB_Prescaler);
+         function To_APBP is new Ada.Unchecked_Conversion
+           (CFGR_PPRE_Field, APB_Prescaler);
+
+         HPRE      : constant AHB_Prescaler := To_AHBP (RCC_Periph.CFGR.HPRE);
+         HPRE_Div  : constant UInt32 := (if HPRE.Enabled
+                                         then HPRE_Presc_Table (HPRE.Value)
+                                         else 1);
+         PPRE      : constant APB_Prescaler := To_APBP (RCC_Periph.CFGR.PPRE);
+         PPRE_Div : constant UInt32 := (if PPRE.Enabled
+                                        then PPRE_Presc_Table (PPRE.Value)
+                                        else 1);
+
+      begin
+         Result.HCLK := Result.SYSCLK / HPRE_Div;
+         Result.PCLK := Result.HCLK   / PPRE_Div;
+
+         if not PPRE.Enabled then
+            Result.TIMCLK := Result.PCLK;
+         else
+            Result.TIMCLK := Result.PCLK * 2;
+         end if;
+      end;
+
+      return Result;
+   end System_Clocks;
+
+end System.STM32;

--- a/arm/stm32/stm32f0xx/s-stm32.ads
+++ b/arm/stm32/stm32f0xx/s-stm32.ads
@@ -1,0 +1,187 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--          Copyright (C) 2012-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This file provides register definitions for the STM32F0xx (ARM Cortex M0)
+--  family of microcontrollers from ST Microelectronics.
+
+with Interfaces.STM32;
+
+package System.STM32 is
+   pragma No_Elaboration_Code_All;
+   pragma Preelaborate (System.STM32);
+
+   subtype Frequency is Interfaces.STM32.UInt32;
+
+   type RCC_System_Clocks is record
+      SYSCLK : Frequency;
+      HCLK   : Frequency;
+      PCLK   : Frequency;
+      TIMCLK : Frequency;
+   end record;
+
+   function System_Clocks return RCC_System_Clocks;
+
+   --  MODER constants
+   subtype GPIO_MODER_Values is Interfaces.STM32.UInt2;
+   Mode_IN  : constant GPIO_MODER_Values := 0;
+   Mode_OUT : constant GPIO_MODER_Values := 1;
+   Mode_AF  : constant GPIO_MODER_Values := 2;
+   Mode_AN  : constant GPIO_MODER_Values := 3;
+
+   --  OTYPER constants
+   subtype GPIO_OTYPER_Values is Interfaces.STM32.Bit;
+   Push_Pull  : constant GPIO_OTYPER_Values := 0;
+   Open_Drain : constant GPIO_OTYPER_Values := 1;
+
+   --  OSPEEDR constants
+   subtype GPIO_OSPEEDR_Values is Interfaces.STM32.UInt2;
+   Speed_2MHz   : constant GPIO_OSPEEDR_Values := 0; -- Low speed
+   Speed_25MHz  : constant GPIO_OSPEEDR_Values := 1; -- Medium speed
+   Speed_50MHz  : constant GPIO_OSPEEDR_Values := 2; -- Fast speed
+   Speed_100MHz : constant GPIO_OSPEEDR_Values := 3; -- High speed
+
+   --  PUPDR constants
+   subtype GPIO_PUPDR_Values is Interfaces.STM32.UInt2;
+   No_Pull   : constant GPIO_PUPDR_Values := 0;
+   Pull_Up   : constant GPIO_PUPDR_Values := 1;
+   Pull_Down : constant GPIO_PUPDR_Values := 2;
+
+   type MCU_ID_Register is record
+      DEV_ID   : Interfaces.STM32.UInt12;
+      Reserved : Interfaces.STM32.UInt4;
+      REV_ID   : Interfaces.STM32.UInt16;
+   end record with Pack, Size => 32;
+
+   --  RCC constants
+
+   --  Note that the STM32F03x and STM32F05x devices are limited
+   --  to HSI/2 and HSE clock sources. HSI and HIS48 are not allowed.
+
+   type PLL_Source is
+     (PLL_SRC_HSI_2,        --  HSI/2
+      PLL_SRC_HSI_PREDIV,   --  HSI/PREDIV (only on STM32F04x/F07x/F09x)
+      PLL_SRC_HSE_PREDIV,   --  HSE/PREDIV
+      PLL_SRC_HSI48_PREDIV) --  HSI48/PREDIV (only on STM32F04x/F07x/F09x)
+     with Size => 2;
+
+   type SYSCLK_Source is
+     (SYSCLK_SRC_HSI,
+      SYSCLK_SRC_HSE,
+      SYSCLK_SRC_PLL,
+      SYSCLK_SRC_HSI48)
+     with Size => 2;
+
+   subtype PREDIV_Range is Integer range 1 .. 16;
+
+   type AHB_Prescaler_Enum is
+     (DIV2,  DIV4,   DIV8,   DIV16,
+      DIV64, DIV128, DIV256, DIV512)
+     with Size => 3;
+
+   type AHB_Prescaler is record
+      Enabled : Boolean := False;
+      Value   : AHB_Prescaler_Enum := AHB_Prescaler_Enum'First;
+   end record with Size => 4;
+
+   for AHB_Prescaler use record
+      Enabled at 0 range 3 .. 3;
+      Value   at 0 range 0 .. 2;
+   end record;
+
+   AHBPRE_DIV1 : constant AHB_Prescaler := (Enabled => False, Value => DIV2);
+
+   type APB_Prescaler_Enum is
+     (DIV2,  DIV4,  DIV8,  DIV16)
+     with Size => 2;
+
+   type APB_Prescaler is record
+      Enabled : Boolean;
+      Value   : APB_Prescaler_Enum;
+   end record with Size => 3;
+
+   for APB_Prescaler use record
+      Enabled at 0 range 2 .. 2;
+      Value   at 0 range 0 .. 1;
+   end record;
+
+   APBPRE_DIV1 : constant APB_Prescaler := (Enabled => False, Value => DIV2);
+
+   type I2S_Clock_Selection is
+     (I2SSEL_PLL,
+      I2SSEL_CKIN)
+     with Size => 1;
+
+   type MCO_Clock_Selection is
+     (MCO_None,
+      MCO_HSI14,
+      MCO_LSI,
+      MCO_LSE,
+      MCO_SYSCLK,
+      MCO_HSI,
+      MCO_HSE,
+      MCO_PLL,
+      MCO_HSI48)
+     with Size => 4;
+
+   type MCO_Prescaler is
+     (MCOPRE_DIV1,
+      MCOPRE_DIV2,
+      MCOPRE_DIV4,
+      MCOPRE_DIV8,
+      MCOPRE_DIV16,
+      MCOPRE_DIV32,
+      MCOPRE_DIV64,
+      MCOPRE_DIV128)
+     with Size => 3;
+
+   --  Constants for RCC CR register
+
+   subtype PLLMUL_Range is Integer range 2 .. 16;
+
+   subtype HSECLK_Range is Integer range   4_000_000 .. 32_000_000;
+   subtype PLLOUT_Range is Integer range  16_000_000 .. 48_000_000;
+   subtype SYSCLK_Range is Integer range           1 .. 48_000_000;
+   subtype HCLK_Range   is Integer range           1 .. 48_000_000;
+   subtype PCLK_Range   is Integer range           1 .. 48_000_000;
+
+   --  These internal low and high speed clocks are fixed (do not modify)
+
+   HSICLK   : constant :=  8_000_000;
+   HSI48CLK : constant := 48_000_000; --  HSI48 only present on F05X/07x/F09x
+   LSICLK   : constant :=     32_000;
+
+   MCU_ID : MCU_ID_Register with Volatile,
+                                 Address => System'To_Address (16#E004_2000#);
+   --  Only 32-bits access supported (read-only)
+
+   DEV_ID_STM32F03x : constant := 16#444#;
+   DEV_ID_STM32F04x : constant := 16#445#;
+   DEV_ID_STM32F05x : constant := 16#440#;
+   DEV_ID_STM32F07x : constant := 16#448#;
+   DEV_ID_STM32F09x : constant := 16#442#;
+
+end System.STM32;

--- a/arm/stm32/stm32f0xx/setup_pll.adb
+++ b/arm/stm32/stm32f0xx/setup_pll.adb
@@ -1,0 +1,263 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--          Copyright (C) 2012-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+pragma Ada_2012; -- To work around pre-commit check?
+pragma Suppress (All_Checks);
+
+--  This initialization procedure mainly initializes the PLLs and
+--  all derived clocks.
+
+with Ada.Unchecked_Conversion;
+
+with Interfaces.STM32;           use Interfaces, Interfaces.STM32;
+with Interfaces.STM32.Flash;     use Interfaces.STM32.Flash;
+with Interfaces.STM32.RCC;       use Interfaces.STM32.RCC;
+
+with System.BB.Parameters;       use System.BB.Parameters;
+with System.BB.Board_Parameters; use System.BB.Board_Parameters;
+with System.BB.MCU_Parameters;   use System.BB.MCU_Parameters;
+with System.STM32;               use System.STM32;
+
+procedure Setup_Pll is
+   procedure Initialize_Clocks;
+   procedure Reset_Clocks;
+
+   ------------------------------
+   -- Clock Tree Configuration --
+   ------------------------------
+
+   Activate_PLL : constant Boolean := SYSCLK_Src = SYSCLK_SRC_PLL;
+
+   --  Enable HSE if used to generate the system clock (either directly,
+   --  or indirectly via the PLL).
+
+   HSE_Enabled : constant Boolean :=
+     (SYSCLK_Src = System.STM32.SYSCLK_SRC_HSE
+      or (SYSCLK_Src = System.STM32.SYSCLK_SRC_PLL
+          and PLL_Src = System.STM32.PLL_SRC_HSE_PREDIV));
+
+   -----------------------
+   -- Initialize_Clocks --
+   -----------------------
+
+   procedure Initialize_Clocks
+   is
+      -------------------------------
+      -- Compute Clock Frequencies --
+      -------------------------------
+
+      pragma Compile_Time_Error
+        (HSE_Clock_Frequency not in HSECLK_Range,
+         "Invalid HSE clock configuration value");
+
+      pragma Compile_Time_Error
+        (PLLMUL_Value not in PLLMUL_Range,
+         "Invalid PLLMUL_Value configuration value");
+
+      pragma Compile_Time_Error
+        (Simple_Clock_Tree
+         and PLL_Src not in PLL_SRC_HSI_2 | PLL_SRC_HSE_PREDIV,
+         "PLL source must be HSI/2 or HSE on STM32F03x/STM32F05x devices");
+
+      pragma Compile_Time_Error
+        (Simple_Clock_Tree
+         and (PLL_Src = PLL_SRC_HSI48_PREDIV
+              or SYSCLK_Src = SYSCLK_SRC_HSI48),
+         "HSI48 clock not present on STM32F03x/STM32F05x devices");
+
+      pragma Compile_Time_Error
+        (Activate_PLL
+         and PLL_Src = PLL_SRC_HSE_PREDIV
+         and not HSE_Enabled,
+         "HSE clock must be enabled to use as PLL input");
+
+      pragma Compile_Time_Error
+        (SYSCLK_Src = SYSCLK_SRC_HSE
+         and not HSE_Enabled,
+         "HSE clock must be enabled to use in SYSCLK generation");
+
+      PLLCLKIN : constant Integer :=
+        (case PLL_Src is
+            when PLL_SRC_HSI_2        => HSICLK / 2,
+            when PLL_SRC_HSI_PREDIV   => HSICLK / PREDIV,
+            when PLL_SRC_HSE_PREDIV   => HSE_Clock_Frequency / PREDIV,
+            when PLL_SRC_HSI48_PREDIV => HSI48CLK / PREDIV);
+
+      PLLCLKOUT : constant Integer := PLLCLKIN * PLLMUL_Value;
+
+      pragma Compile_Time_Error
+        (Activate_PLL and PLLCLKOUT not in PLLOUT_Range,
+         "Invalid PLL clock output value");
+
+      SW_Value    : constant CFGR_SW_Field :=
+                      SYSCLK_Source'Enum_Rep (SYSCLK_Src);
+
+      SYSCLK      : constant Integer :=
+        (case SYSCLK_Src is
+            when SYSCLK_SRC_HSI   => HSICLK,
+            when SYSCLK_SRC_HSE   => HSE_Clock_Frequency,
+            when SYSCLK_SRC_PLL   => PLLCLKOUT,
+            when SYSCLK_SRC_HSI48 => HSI48CLK);
+
+      HCLK        : constant Integer :=
+                      (if not AHB_PRE.Enabled
+                       then SYSCLK
+                       else
+                         (case AHB_PRE.Value is
+                             when DIV2   => SYSCLK / 2,
+                             when DIV4   => SYSCLK / 4,
+                             when DIV8   => SYSCLK / 8,
+                             when DIV16  => SYSCLK / 16,
+                             when DIV64  => SYSCLK / 64,
+                             when DIV128 => SYSCLK / 128,
+                             when DIV256 => SYSCLK / 256,
+                             when DIV512 => SYSCLK / 512));
+      PCLK        : constant Integer :=
+                      (if not APB_PRE.Enabled
+                       then HCLK
+                       else
+                         (case APB_PRE.Value is
+                             when DIV2  => HCLK / 2,
+                             when DIV4  => HCLK / 4,
+                             when DIV8  => HCLK / 8,
+                             when DIV16 => HCLK / 16));
+
+      function To_AHB is new Ada.Unchecked_Conversion
+        (AHB_Prescaler, UInt4);
+      function To_APB is new Ada.Unchecked_Conversion
+        (APB_Prescaler, UInt3);
+
+   begin
+
+      pragma Compile_Time_Error
+        (SYSCLK /= Clock_Frequency,
+           "Cannot generate requested clock");
+
+      --  Cannot be checked at compile time, depends on APB_PRE
+      pragma Assert
+        (HCLK not in HCLK_Range
+         or else PCLK not in PCLK_Range,
+         "Invalid AHB/APB prescalers configuration");
+
+      if not HSE_Enabled then
+         --  Setup internal clock and wait for HSI stabilisation.
+
+         RCC_Periph.CR.HSION := 1;
+
+         loop
+            exit when RCC_Periph.CR.HSIRDY = 1;
+         end loop;
+
+      else
+         --  Configure high-speed external clock, if enabled
+
+         RCC_Periph.CR.HSEON := 1;
+         RCC_Periph.CR.HSEBYP := (if HSE_Bypass then 1 else 0);
+
+         loop
+            exit when RCC_Periph.CR.HSERDY = 1;
+         end loop;
+      end if;
+
+      --  Configure low-speed internal clock if enabled
+
+      if LSI_Enabled then
+         RCC_Periph.CSR.LSION := 1;
+
+         loop
+            exit when RCC_Periph.CSR.LSIRDY = 1;
+         end loop;
+      end if;
+
+      --  Activate PLL if enabled
+      if Activate_PLL then
+         --  Disable the main PLL before configuring it
+         RCC_Periph.CR.PLLON := 0;
+
+         --  Configure the PLL clock source, multiplication and division
+         --  factors
+         RCC_Periph.CFGR2.PREDIV := UInt4 (PREDIV - 1);
+         RCC_Periph.CFGR.PLLMUL  := PLLMUL_Value - 2;
+         RCC_Periph.CFGR.PLLSRC  := PLL_Source'Enum_Rep (PLL_Src);
+
+         RCC_Periph.CR.PLLON := 1;
+         loop
+            exit when RCC_Periph.CR.PLLRDY = 1;
+         end loop;
+      end if;
+
+      --  Configure flash
+      --  Must be done before increasing the frequency, otherwise the CPU
+      --  won't be able to fetch new instructions.
+
+      Flash_Periph.ACR.PRFTBE := 1;
+
+      --  Use zero wait states when SYSCLK <= 24 MHz otherwise one wait state
+      Flash_Periph.ACR.LATENCY := UInt3 ((SYSCLK - 1) / 24_000_000);
+
+      --  Configure derived clocks
+
+      RCC_Periph.CFGR.HPRE := To_AHB (AHB_PRE);
+      RCC_Periph.CFGR.PPRE := To_APB (APB_PRE);
+      RCC_Periph.CFGR.SW   := SW_Value;
+
+      if Activate_PLL then
+         loop
+            exit when RCC_Periph.CFGR.SWS =
+              SYSCLK_Source'Enum_Rep (SYSCLK_SRC_PLL);
+         end loop;
+      end if;
+   end Initialize_Clocks;
+
+   ------------------
+   -- Reset_Clocks --
+   ------------------
+
+   procedure Reset_Clocks is
+   begin
+      --  Switch on high speed internal clock
+      RCC_Periph.CR.HSION := 1;
+
+      --  Reset CFGR regiser
+      RCC_Periph.CFGR := (others => <>);
+
+      --  Reset HSEON, CSSON and PLLON bits
+      RCC_Periph.CR.HSEON := 0;
+      RCC_Periph.CR.CSSON := 0;
+      RCC_Periph.CR.PLLON := 0;
+
+      --  Reset HSE bypass bit
+      RCC_Periph.CR.HSEBYP := 0;
+
+      --  Disable all interrupts
+      RCC_Periph.CIR := (others => <>);
+   end Reset_Clocks;
+
+begin
+   Reset_Clocks;
+   Initialize_Clocks;
+end Setup_Pll;

--- a/arm/stm32/stm32f0xx/setup_pll.ads
+++ b/arm/stm32/stm32f0xx/setup_pll.ads
@@ -1,0 +1,34 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--          Copyright (C) 2012-2020, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+pragma Suppress (All_Checks);
+
+procedure Setup_Pll;
+
+pragma No_Elaboration_Code_All (Setup_Pll);
+--  This code is executed before elaboration, so better not need elaboration
+--  code.

--- a/arm/stm32/stm32f0xx/start-ram.S
+++ b/arm/stm32/stm32f0xx/start-ram.S
@@ -1,0 +1,150 @@
+## -*- asm -*- ##############################################################
+#                                                                           #
+#                 GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                  #
+#                                                                           #
+#                                 S T A R T                                 #
+#                                                                           #
+#                               Assembly File                               #
+#                                                                           #
+#                      Copyright (C) 2012-2020 AdaCore                      #
+#                                                                           #
+#  GNAT is free software;  you can  redistribute it  and/or modify it under #
+#  terms of the  GNU General Public License as published  by the Free Soft- #
+#  ware  Foundation;  either version 3,  or (at your option) any later ver- #
+#  sion.  GNAT is distributed in the hope that it will be useful, but WITH- #
+#  OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY #
+#  or FITNESS FOR A PARTICULAR PURPOSE.                                     #
+#                                                                           #
+#  As a special exception under Section 7 of GPL version 3, you are granted #
+#  additional permissions described in the GCC Runtime Library Exception,   #
+#  version 3.1, as published by the Free Software Foundation.               #
+#                                                                           #
+#  You should have received a copy of the GNU General Public License and    #
+#  a copy of the GCC Runtime Library Exception along with this program;     #
+#  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    #
+#  <http://www.gnu.org/licenses/>.                                          #
+#                                                                           #
+#############################################################################
+
+	.syntax unified
+	.cpu cortex-m4
+	.thumb
+
+	/* This is the interrupt vector table used by all runtimes,
+	 * The Cortex-M0 does not support VTOR. */
+	.text
+	.section .vectors,"a"
+	.globl __vectors
+	.p2align 8
+__vectors:
+	/* Cortex-M core interrupts */
+	.word   __stack_end          /* stack top address */
+	.word   _start_ram           /* 1 Reset.  */
+	.word   fault                /* 2 NMI. */
+	.word   fault                /* 3 Hard fault. */
+	.word   fault                /* 4 Mem manage. */
+	.word   fault                /* 5 Bus fault. */
+	.word   fault                /* 6 Usage fault. */
+	.word   fault                /* 7 reserved. */
+	.word   fault                /* 8 reserved. */
+	.word   fault                /* 9 reserved. */
+	.word   fault                /* 10 reserved. */
+	.word   __gnat_sv_call_trap  /* 11 SVCall. */
+	.word   fault                /* 12 reserved. */
+	.word   fault                /* 13 reserved. */
+	.word   __gnat_pend_sv_trap  /* 14 PendSV. */
+	.word   __gnat_sys_tick_trap /* 15 Systick. */
+	/* MCU interrupts */
+	.word __gnat_irq_trap        /* 16 WWDG */
+	.word __gnat_irq_trap        /* 17 PVD */
+	.word __gnat_irq_trap        /* 18 RTC */
+	.word __gnat_irq_trap        /* 19 FLASH */
+	.word __gnat_irq_trap        /* 20 RCC_CRS */
+	.word __gnat_irq_trap        /* 21 EXTI0_1 */
+	.word __gnat_irq_trap        /* 22 EXTI2_3 */
+	.word __gnat_irq_trap        /* 23 EXTI4_15 */
+	.word __gnat_irq_trap        /* 24 TSC */
+	.word __gnat_irq_trap        /* 25 DMA1_CH1 */
+	.word __gnat_irq_trap        /* 26 DMA1_CH2_3_DMA2_CH1_2 */
+	.word __gnat_irq_trap        /* 27 DMA1_CH4_5_6_7_DMA2_CH3_4_5 */
+	.word __gnat_irq_trap        /* 28 ADC_COMP */
+	.word __gnat_irq_trap        /* 29 TIM1_BRK_UP_TRG_COM */
+	.word __gnat_irq_trap        /* 30 TIM1_CC */
+	.word __gnat_irq_trap        /* 31 TIM2 */
+	.word __gnat_irq_trap        /* 32 TIM3 */
+	.word __gnat_irq_trap        /* 33 TIM6_DAC */
+	.word __gnat_irq_trap        /* 34 TIM7 */
+	.word __gnat_irq_trap        /* 35 TIM14 */
+	.word __gnat_irq_trap        /* 36 TIM15 */
+	.word __gnat_irq_trap        /* 37 TIM16 */
+	.word __gnat_irq_trap        /* 38 TIM17 */
+	.word __gnat_irq_trap        /* 39 I2C1 */
+	.word __gnat_irq_trap        /* 40 I2C2 */
+	.word __gnat_irq_trap        /* 41 SPI1 */
+	.word __gnat_irq_trap        /* 42 SPI2 */
+	.word __gnat_irq_trap        /* 43 USART1 */
+	.word __gnat_irq_trap        /* 44 USART2 */
+	.word __gnat_irq_trap        /* 45 USART3_4_5_6_7_8 */
+	.word __gnat_irq_trap        /* 46 CEC_CAN */
+	.word __gnat_irq_trap        /* 47 USB */
+
+	.text
+	.thumb_func
+	.globl _start_ram
+_start_ram:
+	/* Clear .bss */
+	ldr	r0,=__bss_start
+	ldr	r1,=__bss_words
+	movs	r2,#0
+        cmp	r1,#0
+	beq	1f
+0:	str	r2,[r0]
+        adds	r0,#4
+	subs	r1,r1,#1
+	bne	0b
+
+1:
+        /* Load stack pointer from the first entry of the vector table */
+        ldr     r0,=__vectors
+        ldr     r0, [r0]
+        mov     sp, r0
+
+	bl	_ada_setup_pll
+	bl	main
+
+	bl	_exit
+
+hang:   b .
+
+	.text
+
+	.thumb_func
+.weak __gnat_irq_trap
+.type __gnat_irq_trap, %function
+__gnat_irq_trap:
+0:	b 0b
+	.size __gnat_irq_trap, . - __gnat_irq_trap
+
+	.thumb_func
+.weak __gnat_sv_call_trap
+.type __gnat_sv_call_trap, %function
+__gnat_sv_call_trap:
+0:	b 0b
+	.size __gnat_sv_call_trap, . - __gnat_sv_call_trap
+
+	.thumb_func
+.weak __gnat_pend_sv_trap
+.type __gnat_pend_sv_trap, %function
+__gnat_pend_sv_trap:
+0:	b 0b
+	.size __gnat_pend_sv_trap, . - __gnat_pend_sv_trap
+
+	.thumb_func
+.weak __gnat_sys_tick_trap
+.type __gnat_sys_tick_trap, %function
+__gnat_sys_tick_trap:
+0:	b 0b
+	.size __gnat_sys_tick_trap, . - __gnat_sys_tick_trap
+
+	.thumb_func
+fault:	b fault

--- a/arm/stm32/stm32f0xx/start-rom.S
+++ b/arm/stm32/stm32f0xx/start-rom.S
@@ -1,0 +1,158 @@
+## -*- asm -*- ##############################################################
+#                                                                           #
+#                 GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                  #
+#                                                                           #
+#                                 S T A R T                                 #
+#                                                                           #
+#                               Assembly File                               #
+#                                                                           #
+#                      Copyright (C) 2012-2020 AdaCore                      #
+#                                                                           #
+#  GNAT is free software;  you can  redistribute it  and/or modify it under #
+#  terms of the  GNU General Public License as published  by the Free Soft- #
+#  ware  Foundation;  either version 3,  or (at your option) any later ver- #
+#  sion.  GNAT is distributed in the hope that it will be useful, but WITH- #
+#  OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY #
+#  or FITNESS FOR A PARTICULAR PURPOSE.                                     #
+#                                                                           #
+#  As a special exception under Section 7 of GPL version 3, you are granted #
+#  additional permissions described in the GCC Runtime Library Exception,   #
+#  version 3.1, as published by the Free Software Foundation.               #
+#                                                                           #
+#  You should have received a copy of the GNU General Public License and    #
+#  a copy of the GCC Runtime Library Exception along with this program;     #
+#  see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    #
+#  <http://www.gnu.org/licenses/>.                                          #
+#                                                                           #
+#############################################################################
+
+	.syntax unified
+	.cpu cortex-m0
+	.thumb
+
+	/* This is the interrupt vector table used by all runtimes,
+	 * The Cortex-M0 does not support VTOR. */
+	.text
+	.section .vectors,"a"
+	.globl __vectors
+	.p2align 8
+__vectors:
+	/* Cortex-M core interrupts */
+	.word   __stack_end          /* stack top address */
+	.word   _start_rom           /* 1 Reset.  */
+	.word   fault                /* 2 NMI. */
+	.word   fault                /* 3 Hard fault. */
+	.word   fault                /* 4 Mem manage. */
+	.word   fault                /* 5 Bus fault. */
+	.word   fault                /* 6 Usage fault. */
+	.word   fault                /* 7 reserved. */
+	.word   fault                /* 8 reserved. */
+	.word   fault                /* 9 reserved. */
+	.word   fault                /* 10 reserved. */
+	.word   __gnat_sv_call_trap  /* 11 SVCall. */
+	.word   fault                /* 12 reserved. */
+	.word   fault                /* 13 reserved. */
+	.word   __gnat_pend_sv_trap  /* 14 PendSV. */
+	.word   __gnat_sys_tick_trap /* 15 Systick. */
+	/* MCU interrupts */
+	.word __gnat_irq_trap        /* 16 WWDG */
+	.word __gnat_irq_trap        /* 17 PVD */
+	.word __gnat_irq_trap        /* 18 RTC */
+	.word __gnat_irq_trap        /* 19 FLASH */
+	.word __gnat_irq_trap        /* 20 RCC_CRS */
+	.word __gnat_irq_trap        /* 21 EXTI0_1 */
+	.word __gnat_irq_trap        /* 22 EXTI2_3 */
+	.word __gnat_irq_trap        /* 23 EXTI4_15 */
+	.word __gnat_irq_trap        /* 24 TSC */
+	.word __gnat_irq_trap        /* 25 DMA1_CH1 */
+	.word __gnat_irq_trap        /* 26 DMA1_CH2_3_DMA2_CH1_2 */
+	.word __gnat_irq_trap        /* 27 DMA1_CH4_5_6_7_DMA2_CH3_4_5 */
+	.word __gnat_irq_trap        /* 28 ADC_COMP */
+	.word __gnat_irq_trap        /* 29 TIM1_BRK_UP_TRG_COM */
+	.word __gnat_irq_trap        /* 30 TIM1_CC */
+	.word __gnat_irq_trap        /* 31 TIM2 */
+	.word __gnat_irq_trap        /* 32 TIM3 */
+	.word __gnat_irq_trap        /* 33 TIM6_DAC */
+	.word __gnat_irq_trap        /* 34 TIM7 */
+	.word __gnat_irq_trap        /* 35 TIM14 */
+	.word __gnat_irq_trap        /* 36 TIM15 */
+	.word __gnat_irq_trap        /* 37 TIM16 */
+	.word __gnat_irq_trap        /* 38 TIM17 */
+	.word __gnat_irq_trap        /* 39 I2C1 */
+	.word __gnat_irq_trap        /* 40 I2C2 */
+	.word __gnat_irq_trap        /* 41 SPI1 */
+	.word __gnat_irq_trap        /* 42 SPI2 */
+	.word __gnat_irq_trap        /* 43 USART1 */
+	.word __gnat_irq_trap        /* 44 USART2 */
+	.word __gnat_irq_trap        /* 45 USART3_4_5_6_7_8 */
+	.word __gnat_irq_trap        /* 46 CEC_CAN */
+	.word __gnat_irq_trap        /* 47 USB */
+
+	.text
+	.thumb_func
+	.globl _start_rom
+_start_rom:
+	/* Copy .data */
+	ldr	r0,=__data_start
+	ldr	r1,=__data_words
+	ldr	r2,=__data_load
+        cmp	r1,#0
+	beq	1f
+0:	ldr	r4,[r2]
+	str	r4,[r0]
+        adds	r0,#4
+        adds	r2,#4
+	subs	r1,r1,#1
+	bne	0b
+1:
+	/* Clear .bss */
+	ldr	r0,=__bss_start
+	ldr	r1,=__bss_words
+	movs	r2,#0
+        cmp	r1,#0
+	beq	1f
+0:	str	r2,[r0]
+        adds	r0,#4
+	subs	r1,r1,#1
+	bne	0b
+
+1:
+	bl	_ada_setup_pll
+	bl	main
+
+	bl	_exit
+
+hang:   b .
+
+	.text
+
+	.thumb_func
+.weak __gnat_irq_trap
+.type __gnat_irq_trap, %function
+__gnat_irq_trap:
+0:	b 0b
+	.size __gnat_irq_trap, . - __gnat_irq_trap
+
+	.thumb_func
+.weak __gnat_sv_call_trap
+.type __gnat_sv_call_trap, %function
+__gnat_sv_call_trap:
+0:	b 0b
+	.size __gnat_sv_call_trap, . - __gnat_sv_call_trap
+
+	.thumb_func
+.weak __gnat_pend_sv_trap
+.type __gnat_pend_sv_trap, %function
+__gnat_pend_sv_trap:
+0:	b 0b
+	.size __gnat_pend_sv_trap, . - __gnat_pend_sv_trap
+
+	.thumb_func
+.weak __gnat_sys_tick_trap
+.type __gnat_sys_tick_trap, %function
+__gnat_sys_tick_trap:
+0:	b 0b
+	.size __gnat_sys_tick_trap, . - __gnat_sys_tick_trap
+
+	.thumb_func
+fault:	b fault

--- a/arm/stm32/stm32f0xx/stm32f0x0/svd/a-intnam.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x0/svd/a-intnam.ads
@@ -1,0 +1,105 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x0.svd
+
+--  This is a version for the STM32F0x0 MCU
+package Ada.Interrupts.Names is
+
+   --  All identifiers in this unit are implementation defined
+
+   pragma Implementation_Defined;
+
+   ----------------
+   -- Interrupts --
+   ----------------
+
+   --  System tick
+   Sys_Tick_Interrupt             : constant Interrupt_ID := -1;
+
+   --  Window Watchdog interrupt
+   WWDG_Interrupt                 : constant Interrupt_ID := 0;
+
+   --  PVD and VDDIO2 supply comparator interrupt
+   PVD_Interrupt                  : constant Interrupt_ID := 1;
+
+   --  RTC interrupts
+   RTC_Interrupt                  : constant Interrupt_ID := 2;
+
+   --  Flash global interrupt
+   FLASH_Interrupt                : constant Interrupt_ID := 3;
+
+   --  RCC global interruptr
+   RCC_Interrupt                  : constant Interrupt_ID := 4;
+
+   --  EXTI Line[1:0] interrupts
+   EXTI0_1_Interrupt              : constant Interrupt_ID := 5;
+
+   --  EXTI Line[3:2] interrupts
+   EXTI2_3_Interrupt              : constant Interrupt_ID := 6;
+
+   --  EXTI Line15 and EXTI4 interrupts
+   EXTI4_15_Interrupt             : constant Interrupt_ID := 7;
+
+   --  DMA1 channel 1 interrupt
+   DMA1_CH1_Interrupt             : constant Interrupt_ID := 9;
+
+   --  DMA1 channel 2 and 3 interrupt
+   DMA1_CH2_3_Interrupt           : constant Interrupt_ID := 10;
+
+   --  DMA1 channel 4 and 5 interrupt
+   DMA1_CH4_5_Interrupt           : constant Interrupt_ID := 11;
+
+   --  ADC interrupt
+   ADC_Interrupt                  : constant Interrupt_ID := 12;
+
+   --  TIM1 break, update, trigger and commutation interrupt
+   TIM1_BRK_UP_TRG_COM_Interrupt  : constant Interrupt_ID := 13;
+
+   --  TIM1 Capture Compare interrupt
+   TIM1_CC_Interrupt              : constant Interrupt_ID := 14;
+
+   --  TIM3 global interrupt
+   TIM3_Interrupt                 : constant Interrupt_ID := 16;
+
+   --  TIM6 global interrupt
+   TIM6_Interrupt                 : constant Interrupt_ID := 17;
+
+   --  TIM14 global interrupt
+   TIM14_Interrupt                : constant Interrupt_ID := 19;
+
+   --  TIM15 global interrupt
+   TIM15_Interrupt                : constant Interrupt_ID := 20;
+
+   --  TIM16 global interrupt
+   TIM16_Interrupt                : constant Interrupt_ID := 21;
+
+   --  TIM17 global interrupt
+   TIM17_Interrupt                : constant Interrupt_ID := 22;
+
+   --  I2C1 global interrupt
+   I2C1_Interrupt                 : constant Interrupt_ID := 23;
+
+   --  I2C2 global interrupt
+   I2C2_Interrupt                 : constant Interrupt_ID := 24;
+
+   --  SPI1_global_interrupt
+   SPI1_Interrupt                 : constant Interrupt_ID := 25;
+
+   --  SPI2 global interrupt
+   SPI2_Interrupt                 : constant Interrupt_ID := 26;
+
+   --  USART1 global interrupt
+   USART1_Interrupt               : constant Interrupt_ID := 27;
+
+   --  USART2 global interrupt
+   USART2_Interrupt               : constant Interrupt_ID := 28;
+
+   --  USART3, USART4, USART5, USART6 global interrupt
+   USART3_4_5_6_Interrupt         : constant Interrupt_ID := 29;
+
+   --  USB global interrupt
+   USB_Interrupt                  : constant Interrupt_ID := 31;
+
+end Ada.Interrupts.Names;

--- a/arm/stm32/stm32f0xx/stm32f0x0/svd/i-stm32-flash.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x0/svd/i-stm32-flash.ads
@@ -1,0 +1,269 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x0.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.Flash is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype ACR_LATENCY_Field is Interfaces.STM32.UInt3;
+   subtype ACR_PRFTBE_Field is Interfaces.STM32.Bit;
+   subtype ACR_PRFTBS_Field is Interfaces.STM32.Bit;
+
+   --  Flash access control register
+   type ACR_Register is record
+      --  LATENCY
+      LATENCY       : ACR_LATENCY_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  PRFTBE
+      PRFTBE        : ACR_PRFTBE_Field := 16#1#;
+      --  Read-only. PRFTBS
+      PRFTBS        : ACR_PRFTBS_Field := 16#1#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for ACR_Register use record
+      LATENCY       at 0 range 0 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      PRFTBE        at 0 range 4 .. 4;
+      PRFTBS        at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype SR_BSY_Field is Interfaces.STM32.Bit;
+   subtype SR_PGERR_Field is Interfaces.STM32.Bit;
+   subtype SR_WRPRT_Field is Interfaces.STM32.Bit;
+   subtype SR_EOP_Field is Interfaces.STM32.Bit;
+
+   --  Flash status register
+   type SR_Register is record
+      --  Read-only. Busy
+      BSY           : SR_BSY_Field := 16#0#;
+      --  unspecified
+      Reserved_1_1  : Interfaces.STM32.Bit := 16#0#;
+      --  Programming error
+      PGERR         : SR_PGERR_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  Write protection error
+      WRPRT         : SR_WRPRT_Field := 16#0#;
+      --  End of operation
+      EOP           : SR_EOP_Field := 16#0#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for SR_Register use record
+      BSY           at 0 range 0 .. 0;
+      Reserved_1_1  at 0 range 1 .. 1;
+      PGERR         at 0 range 2 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      WRPRT         at 0 range 4 .. 4;
+      EOP           at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype CR_PG_Field is Interfaces.STM32.Bit;
+   subtype CR_PER_Field is Interfaces.STM32.Bit;
+   subtype CR_MER_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTPG_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTER_Field is Interfaces.STM32.Bit;
+   subtype CR_STRT_Field is Interfaces.STM32.Bit;
+   subtype CR_LOCK_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTWRE_Field is Interfaces.STM32.Bit;
+   subtype CR_ERRIE_Field is Interfaces.STM32.Bit;
+   subtype CR_EOPIE_Field is Interfaces.STM32.Bit;
+   subtype CR_FORCE_OPTLOAD_Field is Interfaces.STM32.Bit;
+
+   --  Flash control register
+   type CR_Register is record
+      --  Programming
+      PG             : CR_PG_Field := 16#0#;
+      --  Page erase
+      PER            : CR_PER_Field := 16#0#;
+      --  Mass erase
+      MER            : CR_MER_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  Option byte programming
+      OPTPG          : CR_OPTPG_Field := 16#0#;
+      --  Option byte erase
+      OPTER          : CR_OPTER_Field := 16#0#;
+      --  Start
+      STRT           : CR_STRT_Field := 16#0#;
+      --  Lock
+      LOCK           : CR_LOCK_Field := 16#1#;
+      --  unspecified
+      Reserved_8_8   : Interfaces.STM32.Bit := 16#0#;
+      --  Option bytes write enable
+      OPTWRE         : CR_OPTWRE_Field := 16#0#;
+      --  Error interrupt enable
+      ERRIE          : CR_ERRIE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_11 : Interfaces.STM32.Bit := 16#0#;
+      --  End of operation interrupt enable
+      EOPIE          : CR_EOPIE_Field := 16#0#;
+      --  Force option byte loading
+      FORCE_OPTLOAD  : CR_FORCE_OPTLOAD_Field := 16#0#;
+      --  unspecified
+      Reserved_14_31 : Interfaces.STM32.UInt18 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      PG             at 0 range 0 .. 0;
+      PER            at 0 range 1 .. 1;
+      MER            at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      OPTPG          at 0 range 4 .. 4;
+      OPTER          at 0 range 5 .. 5;
+      STRT           at 0 range 6 .. 6;
+      LOCK           at 0 range 7 .. 7;
+      Reserved_8_8   at 0 range 8 .. 8;
+      OPTWRE         at 0 range 9 .. 9;
+      ERRIE          at 0 range 10 .. 10;
+      Reserved_11_11 at 0 range 11 .. 11;
+      EOPIE          at 0 range 12 .. 12;
+      FORCE_OPTLOAD  at 0 range 13 .. 13;
+      Reserved_14_31 at 0 range 14 .. 31;
+   end record;
+
+   subtype OBR_OPTERR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RDPRT_Field is Interfaces.STM32.UInt2;
+   subtype OBR_WDG_SW_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STOP_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STDBY_Field is Interfaces.STM32.Bit;
+   subtype OBR_nBOOT1_Field is Interfaces.STM32.Bit;
+   subtype OBR_VDDA_MONITOR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RAM_PARITY_CHECK_Field is Interfaces.STM32.Bit;
+   --  OBR_Data array element
+   subtype OBR_Data_Element is Interfaces.STM32.Byte;
+
+   --  OBR_Data array
+   type OBR_Data_Field_Array is array (0 .. 1) of OBR_Data_Element
+     with Component_Size => 8, Size => 16;
+
+   --  Type definition for OBR_Data
+   type OBR_Data_Field
+     (As_Array : Boolean := False)
+   is record
+      case As_Array is
+         when False =>
+            --  Data as a value
+            Val : Interfaces.STM32.UInt16;
+         when True =>
+            --  Data as an array
+            Arr : OBR_Data_Field_Array;
+      end case;
+   end record
+     with Unchecked_Union, Size => 16;
+
+   for OBR_Data_Field use record
+      Val at 0 range 0 .. 15;
+      Arr at 0 range 0 .. 15;
+   end record;
+
+   --  Option byte register
+   type OBR_Register is record
+      --  Read-only. Option byte error
+      OPTERR           : OBR_OPTERR_Field;
+      --  Read-only. Read protection level status
+      RDPRT            : OBR_RDPRT_Field;
+      --  unspecified
+      Reserved_3_7     : Interfaces.STM32.UInt5;
+      --  Read-only. WDG_SW
+      WDG_SW           : OBR_WDG_SW_Field;
+      --  Read-only. nRST_STOP
+      nRST_STOP        : OBR_nRST_STOP_Field;
+      --  Read-only. nRST_STDBY
+      nRST_STDBY       : OBR_nRST_STDBY_Field;
+      --  unspecified
+      Reserved_11_11   : Interfaces.STM32.Bit;
+      --  Read-only. BOOT1
+      nBOOT1           : OBR_nBOOT1_Field;
+      --  Read-only. VDDA_MONITOR
+      VDDA_MONITOR     : OBR_VDDA_MONITOR_Field;
+      --  Read-only. RAM_PARITY_CHECK
+      RAM_PARITY_CHECK : OBR_RAM_PARITY_CHECK_Field;
+      --  unspecified
+      Reserved_15_15   : Interfaces.STM32.Bit;
+      --  Read-only. Data0
+      Data             : OBR_Data_Field;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for OBR_Register use record
+      OPTERR           at 0 range 0 .. 0;
+      RDPRT            at 0 range 1 .. 2;
+      Reserved_3_7     at 0 range 3 .. 7;
+      WDG_SW           at 0 range 8 .. 8;
+      nRST_STOP        at 0 range 9 .. 9;
+      nRST_STDBY       at 0 range 10 .. 10;
+      Reserved_11_11   at 0 range 11 .. 11;
+      nBOOT1           at 0 range 12 .. 12;
+      VDDA_MONITOR     at 0 range 13 .. 13;
+      RAM_PARITY_CHECK at 0 range 14 .. 14;
+      Reserved_15_15   at 0 range 15 .. 15;
+      Data             at 0 range 16 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Flash
+   type Flash_Peripheral is record
+      --  Flash access control register
+      ACR     : aliased ACR_Register;
+      --  Flash key register
+      KEYR    : aliased Interfaces.STM32.UInt32;
+      --  Flash option key register
+      OPTKEYR : aliased Interfaces.STM32.UInt32;
+      --  Flash status register
+      SR      : aliased SR_Register;
+      --  Flash control register
+      CR      : aliased CR_Register;
+      --  Flash address register
+      AR      : aliased Interfaces.STM32.UInt32;
+      --  Option byte register
+      OBR     : aliased OBR_Register;
+      --  Write protection register
+      WRPR    : aliased Interfaces.STM32.UInt32;
+   end record
+     with Volatile;
+
+   for Flash_Peripheral use record
+      ACR     at 16#0# range 0 .. 31;
+      KEYR    at 16#4# range 0 .. 31;
+      OPTKEYR at 16#8# range 0 .. 31;
+      SR      at 16#C# range 0 .. 31;
+      CR      at 16#10# range 0 .. 31;
+      AR      at 16#14# range 0 .. 31;
+      OBR     at 16#1C# range 0 .. 31;
+      WRPR    at 16#20# range 0 .. 31;
+   end record;
+
+   --  Flash
+   Flash_Periph : aliased Flash_Peripheral
+     with Import, Address => Flash_Base;
+
+end Interfaces.STM32.Flash;

--- a/arm/stm32/stm32f0xx/stm32f0x0/svd/i-stm32-rcc.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x0/svd/i-stm32-rcc.ads
@@ -1,0 +1,926 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x0.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.RCC is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype CR_HSION_Field is Interfaces.STM32.Bit;
+   subtype CR_HSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSITRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR_HSICAL_Field is Interfaces.STM32.Byte;
+   subtype CR_HSEON_Field is Interfaces.STM32.Bit;
+   subtype CR_HSERDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSEBYP_Field is Interfaces.STM32.Bit;
+   subtype CR_CSSON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLRDY_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register
+   type CR_Register is record
+      --  Internal High Speed clock enable
+      HSION          : CR_HSION_Field := 16#1#;
+      --  Read-only. Internal High Speed clock ready flag
+      HSIRDY         : CR_HSIRDY_Field := 16#1#;
+      --  unspecified
+      Reserved_2_2   : Interfaces.STM32.Bit := 16#0#;
+      --  Internal High Speed clock trimming
+      HSITRIM        : CR_HSITRIM_Field := 16#10#;
+      --  Read-only. Internal High Speed clock Calibration
+      HSICAL         : CR_HSICAL_Field := 16#0#;
+      --  External High Speed clock enable
+      HSEON          : CR_HSEON_Field := 16#0#;
+      --  Read-only. External High Speed clock ready flag
+      HSERDY         : CR_HSERDY_Field := 16#0#;
+      --  External High Speed clock Bypass
+      HSEBYP         : CR_HSEBYP_Field := 16#0#;
+      --  Clock Security System enable
+      CSSON          : CR_CSSON_Field := 16#0#;
+      --  unspecified
+      Reserved_20_23 : Interfaces.STM32.UInt4 := 16#0#;
+      --  PLL enable
+      PLLON          : CR_PLLON_Field := 16#0#;
+      --  Read-only. PLL clock ready flag
+      PLLRDY         : CR_PLLRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_26_31 : Interfaces.STM32.UInt6 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      HSION          at 0 range 0 .. 0;
+      HSIRDY         at 0 range 1 .. 1;
+      Reserved_2_2   at 0 range 2 .. 2;
+      HSITRIM        at 0 range 3 .. 7;
+      HSICAL         at 0 range 8 .. 15;
+      HSEON          at 0 range 16 .. 16;
+      HSERDY         at 0 range 17 .. 17;
+      HSEBYP         at 0 range 18 .. 18;
+      CSSON          at 0 range 19 .. 19;
+      Reserved_20_23 at 0 range 20 .. 23;
+      PLLON          at 0 range 24 .. 24;
+      PLLRDY         at 0 range 25 .. 25;
+      Reserved_26_31 at 0 range 26 .. 31;
+   end record;
+
+   subtype CFGR_SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_SWS_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_HPRE_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_PPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_ADCPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLSRC_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_PLLXTPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLMUL_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_MCO_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_MCOPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_PLLNODIV_Field is Interfaces.STM32.Bit;
+
+   --  Clock configuration register (RCC_CFGR)
+   type CFGR_Register is record
+      --  System clock Switch
+      SW             : CFGR_SW_Field := 16#0#;
+      --  Read-only. System Clock Switch Status
+      SWS            : CFGR_SWS_Field := 16#0#;
+      --  AHB prescaler
+      HPRE           : CFGR_HPRE_Field := 16#0#;
+      --  APB Low speed prescaler (APB1)
+      PPRE           : CFGR_PPRE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_13 : Interfaces.STM32.UInt3 := 16#0#;
+      --  ADC prescaler
+      ADCPRE         : CFGR_ADCPRE_Field := 16#0#;
+      --  PLL input clock source
+      PLLSRC         : CFGR_PLLSRC_Field := 16#0#;
+      --  HSE divider for PLL entry
+      PLLXTPRE       : CFGR_PLLXTPRE_Field := 16#0#;
+      --  PLL Multiplication Factor
+      PLLMUL         : CFGR_PLLMUL_Field := 16#0#;
+      --  unspecified
+      Reserved_22_23 : Interfaces.STM32.UInt2 := 16#0#;
+      --  Microcontroller clock output
+      MCO            : CFGR_MCO_Field := 16#0#;
+      --  unspecified
+      Reserved_27_27 : Interfaces.STM32.Bit := 16#0#;
+      --  Microcontroller Clock Output Prescaler
+      MCOPRE         : CFGR_MCOPRE_Field := 16#0#;
+      --  PLL clock not divided for MCO
+      PLLNODIV       : CFGR_PLLNODIV_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR_Register use record
+      SW             at 0 range 0 .. 1;
+      SWS            at 0 range 2 .. 3;
+      HPRE           at 0 range 4 .. 7;
+      PPRE           at 0 range 8 .. 10;
+      Reserved_11_13 at 0 range 11 .. 13;
+      ADCPRE         at 0 range 14 .. 14;
+      PLLSRC         at 0 range 15 .. 16;
+      PLLXTPRE       at 0 range 17 .. 17;
+      PLLMUL         at 0 range 18 .. 21;
+      Reserved_22_23 at 0 range 22 .. 23;
+      MCO            at 0 range 24 .. 26;
+      Reserved_27_27 at 0 range 27 .. 27;
+      MCOPRE         at 0 range 28 .. 30;
+      PLLNODIV       at 0 range 31 .. 31;
+   end record;
+
+   subtype CIR_LSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSC_Field is Interfaces.STM32.Bit;
+
+   --  Clock interrupt register (RCC_CIR)
+   type CIR_Register is record
+      --  Read-only. LSI Ready Interrupt flag
+      LSIRDYF        : CIR_LSIRDYF_Field := 16#0#;
+      --  Read-only. LSE Ready Interrupt flag
+      LSERDYF        : CIR_LSERDYF_Field := 16#0#;
+      --  Read-only. HSI Ready Interrupt flag
+      HSIRDYF        : CIR_HSIRDYF_Field := 16#0#;
+      --  Read-only. HSE Ready Interrupt flag
+      HSERDYF        : CIR_HSERDYF_Field := 16#0#;
+      --  Read-only. PLL Ready Interrupt flag
+      PLLRDYF        : CIR_PLLRDYF_Field := 16#0#;
+      --  Read-only. HSI14 ready interrupt flag
+      HSI14RDYF      : CIR_HSI14RDYF_Field := 16#0#;
+      --  Read-only. HSI48 ready interrupt flag
+      HSI48RDYF      : CIR_HSI48RDYF_Field := 16#0#;
+      --  Read-only. Clock Security System Interrupt flag
+      CSSF           : CIR_CSSF_Field := 16#0#;
+      --  LSI Ready Interrupt Enable
+      LSIRDYIE       : CIR_LSIRDYIE_Field := 16#0#;
+      --  LSE Ready Interrupt Enable
+      LSERDYIE       : CIR_LSERDYIE_Field := 16#0#;
+      --  HSI Ready Interrupt Enable
+      HSIRDYIE       : CIR_HSIRDYIE_Field := 16#0#;
+      --  HSE Ready Interrupt Enable
+      HSERDYIE       : CIR_HSERDYIE_Field := 16#0#;
+      --  PLL Ready Interrupt Enable
+      PLLRDYIE       : CIR_PLLRDYIE_Field := 16#0#;
+      --  HSI14 ready interrupt enable
+      HSI14RDYE      : CIR_HSI14RDYE_Field := 16#0#;
+      --  HSI48 ready interrupt enable
+      HSI48RDYIE     : CIR_HSI48RDYIE_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  Write-only. LSI Ready Interrupt Clear
+      LSIRDYC        : CIR_LSIRDYC_Field := 16#0#;
+      --  Write-only. LSE Ready Interrupt Clear
+      LSERDYC        : CIR_LSERDYC_Field := 16#0#;
+      --  Write-only. HSI Ready Interrupt Clear
+      HSIRDYC        : CIR_HSIRDYC_Field := 16#0#;
+      --  Write-only. HSE Ready Interrupt Clear
+      HSERDYC        : CIR_HSERDYC_Field := 16#0#;
+      --  Write-only. PLL Ready Interrupt Clear
+      PLLRDYC        : CIR_PLLRDYC_Field := 16#0#;
+      --  Write-only. HSI 14 MHz Ready Interrupt Clear
+      HSI14RDYC      : CIR_HSI14RDYC_Field := 16#0#;
+      --  Write-only. HSI48 Ready Interrupt Clear
+      HSI48RDYC      : CIR_HSI48RDYC_Field := 16#0#;
+      --  Write-only. Clock security system interrupt clear
+      CSSC           : CIR_CSSC_Field := 16#0#;
+      --  unspecified
+      Reserved_24_31 : Interfaces.STM32.Byte := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CIR_Register use record
+      LSIRDYF        at 0 range 0 .. 0;
+      LSERDYF        at 0 range 1 .. 1;
+      HSIRDYF        at 0 range 2 .. 2;
+      HSERDYF        at 0 range 3 .. 3;
+      PLLRDYF        at 0 range 4 .. 4;
+      HSI14RDYF      at 0 range 5 .. 5;
+      HSI48RDYF      at 0 range 6 .. 6;
+      CSSF           at 0 range 7 .. 7;
+      LSIRDYIE       at 0 range 8 .. 8;
+      LSERDYIE       at 0 range 9 .. 9;
+      HSIRDYIE       at 0 range 10 .. 10;
+      HSERDYIE       at 0 range 11 .. 11;
+      PLLRDYIE       at 0 range 12 .. 12;
+      HSI14RDYE      at 0 range 13 .. 13;
+      HSI48RDYIE     at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      LSIRDYC        at 0 range 16 .. 16;
+      LSERDYC        at 0 range 17 .. 17;
+      HSIRDYC        at 0 range 18 .. 18;
+      HSERDYC        at 0 range 19 .. 19;
+      PLLRDYC        at 0 range 20 .. 20;
+      HSI14RDYC      at 0 range 21 .. 21;
+      HSI48RDYC      at 0 range 22 .. 22;
+      CSSC           at 0 range 23 .. 23;
+      Reserved_24_31 at 0 range 24 .. 31;
+   end record;
+
+   subtype APB2RSTR_SYSCFGRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_ADCRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_SPI1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_USART1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM15RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM16RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM17RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_DBGMCURST_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral reset register (RCC_APB2RSTR)
+   type APB2RSTR_Register is record
+      --  SYSCFG and COMP reset
+      SYSCFGRST      : APB2RSTR_SYSCFGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_1_8   : Interfaces.STM32.Byte := 16#0#;
+      --  ADC interface reset
+      ADCRST         : APB2RSTR_ADCRST_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 timer reset
+      TIM1RST        : APB2RSTR_TIM1RST_Field := 16#0#;
+      --  SPI 1 reset
+      SPI1RST        : APB2RSTR_SPI1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 reset
+      USART1RST      : APB2RSTR_USART1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer reset
+      TIM15RST       : APB2RSTR_TIM15RST_Field := 16#0#;
+      --  TIM16 timer reset
+      TIM16RST       : APB2RSTR_TIM16RST_Field := 16#0#;
+      --  TIM17 timer reset
+      TIM17RST       : APB2RSTR_TIM17RST_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  Debug MCU reset
+      DBGMCURST      : APB2RSTR_DBGMCURST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2RSTR_Register use record
+      SYSCFGRST      at 0 range 0 .. 0;
+      Reserved_1_8   at 0 range 1 .. 8;
+      ADCRST         at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1RST        at 0 range 11 .. 11;
+      SPI1RST        at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1RST      at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15RST       at 0 range 16 .. 16;
+      TIM16RST       at 0 range 17 .. 17;
+      TIM17RST       at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCURST      at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1RSTR_TIM3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM6RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM7RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM14RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_WWDGRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_SPI2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART4RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART5RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C1RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_PWRRST_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral reset register (RCC_APB1RSTR)
+   type APB1RSTR_Register is record
+      --  unspecified
+      Reserved_0_0   : Interfaces.STM32.Bit := 16#0#;
+      --  Timer 3 reset
+      TIM3RST        : APB1RSTR_TIM3RST_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 reset
+      TIM6RST        : APB1RSTR_TIM6RST_Field := 16#0#;
+      --  TIM7 timer reset
+      TIM7RST        : APB1RSTR_TIM7RST_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 reset
+      TIM14RST       : APB1RSTR_TIM14RST_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog reset
+      WWDGRST        : APB1RSTR_WWDGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI2 reset
+      SPI2RST        : APB1RSTR_SPI2RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 reset
+      USART2RST      : APB1RSTR_USART2RST_Field := 16#0#;
+      --  USART3 reset
+      USART3RST      : APB1RSTR_USART3RST_Field := 16#0#;
+      --  USART4 reset
+      USART4RST      : APB1RSTR_USART4RST_Field := 16#0#;
+      --  USART5 reset
+      USART5RST      : APB1RSTR_USART5RST_Field := 16#0#;
+      --  I2C1 reset
+      I2C1RST        : APB1RSTR_I2C1RST_Field := 16#0#;
+      --  I2C2 reset
+      I2C2RST        : APB1RSTR_I2C2RST_Field := 16#0#;
+      --  USB interface reset
+      USBRST         : APB1RSTR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_27 : Interfaces.STM32.UInt4 := 16#0#;
+      --  Power interface reset
+      PWRRST         : APB1RSTR_PWRRST_Field := 16#0#;
+      --  unspecified
+      Reserved_29_31 : Interfaces.STM32.UInt3 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1RSTR_Register use record
+      Reserved_0_0   at 0 range 0 .. 0;
+      TIM3RST        at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6RST        at 0 range 4 .. 4;
+      TIM7RST        at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14RST       at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGRST        at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2RST        at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2RST      at 0 range 17 .. 17;
+      USART3RST      at 0 range 18 .. 18;
+      USART4RST      at 0 range 19 .. 19;
+      USART5RST      at 0 range 20 .. 20;
+      I2C1RST        at 0 range 21 .. 21;
+      I2C2RST        at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_27 at 0 range 24 .. 27;
+      PWRRST         at 0 range 28 .. 28;
+      Reserved_29_31 at 0 range 29 .. 31;
+   end record;
+
+   subtype AHBENR_DMA1EN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_SRAMEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_FLITFEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_CRCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPAEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPBEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPFEN_Field is Interfaces.STM32.Bit;
+
+   --  AHB Peripheral Clock enable register (RCC_AHBENR)
+   type AHBENR_Register is record
+      --  DMA1 clock enable
+      DMA1EN         : AHBENR_DMA1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_1_1   : Interfaces.STM32.Bit := 16#0#;
+      --  SRAM interface clock enable
+      SRAMEN         : AHBENR_SRAMEN_Field := 16#1#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  FLITF clock enable
+      FLITFEN        : AHBENR_FLITFEN_Field := 16#1#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  CRC clock enable
+      CRCEN          : AHBENR_CRCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_7_16  : Interfaces.STM32.UInt10 := 16#0#;
+      --  I/O port A clock enable
+      IOPAEN         : AHBENR_IOPAEN_Field := 16#0#;
+      --  I/O port B clock enable
+      IOPBEN         : AHBENR_IOPBEN_Field := 16#0#;
+      --  I/O port C clock enable
+      IOPCEN         : AHBENR_IOPCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_20_21 : Interfaces.STM32.UInt2 := 16#0#;
+      --  I/O port F clock enable
+      IOPFEN         : AHBENR_IOPFEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBENR_Register use record
+      DMA1EN         at 0 range 0 .. 0;
+      Reserved_1_1   at 0 range 1 .. 1;
+      SRAMEN         at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      FLITFEN        at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CRCEN          at 0 range 6 .. 6;
+      Reserved_7_16  at 0 range 7 .. 16;
+      IOPAEN         at 0 range 17 .. 17;
+      IOPBEN         at 0 range 18 .. 18;
+      IOPCEN         at 0 range 19 .. 19;
+      Reserved_20_21 at 0 range 20 .. 21;
+      IOPFEN         at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB2ENR_SYSCFGEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_ADCEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_SPI1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_USART1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM15EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM16EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM17EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_DBGMCUEN_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral clock enable register (RCC_APB2ENR)
+   type APB2ENR_Register is record
+      --  SYSCFG clock enable
+      SYSCFGEN       : APB2ENR_SYSCFGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_1_8   : Interfaces.STM32.Byte := 16#0#;
+      --  ADC 1 interface clock enable
+      ADCEN          : APB2ENR_ADCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 Timer clock enable
+      TIM1EN         : APB2ENR_TIM1EN_Field := 16#0#;
+      --  SPI 1 clock enable
+      SPI1EN         : APB2ENR_SPI1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 clock enable
+      USART1EN       : APB2ENR_USART1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer clock enable
+      TIM15EN        : APB2ENR_TIM15EN_Field := 16#0#;
+      --  TIM16 timer clock enable
+      TIM16EN        : APB2ENR_TIM16EN_Field := 16#0#;
+      --  TIM17 timer clock enable
+      TIM17EN        : APB2ENR_TIM17EN_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  MCU debug module clock enable
+      DBGMCUEN       : APB2ENR_DBGMCUEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2ENR_Register use record
+      SYSCFGEN       at 0 range 0 .. 0;
+      Reserved_1_8   at 0 range 1 .. 8;
+      ADCEN          at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1EN         at 0 range 11 .. 11;
+      SPI1EN         at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1EN       at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15EN        at 0 range 16 .. 16;
+      TIM16EN        at 0 range 17 .. 17;
+      TIM17EN        at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCUEN       at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1ENR_TIM3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM6EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM7EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM14EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_WWDGEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_SPI2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART4EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART5EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C1EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_PWREN_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral clock enable register (RCC_APB1ENR)
+   type APB1ENR_Register is record
+      --  unspecified
+      Reserved_0_0   : Interfaces.STM32.Bit := 16#0#;
+      --  Timer 3 clock enable
+      TIM3EN         : APB1ENR_TIM3EN_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 clock enable
+      TIM6EN         : APB1ENR_TIM6EN_Field := 16#0#;
+      --  TIM7 timer clock enable
+      TIM7EN         : APB1ENR_TIM7EN_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 clock enable
+      TIM14EN        : APB1ENR_TIM14EN_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog clock enable
+      WWDGEN         : APB1ENR_WWDGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI 2 clock enable
+      SPI2EN         : APB1ENR_SPI2EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 clock enable
+      USART2EN       : APB1ENR_USART2EN_Field := 16#0#;
+      --  USART3 clock enable
+      USART3EN       : APB1ENR_USART3EN_Field := 16#0#;
+      --  USART4 clock enable
+      USART4EN       : APB1ENR_USART4EN_Field := 16#0#;
+      --  USART5 clock enable
+      USART5EN       : APB1ENR_USART5EN_Field := 16#0#;
+      --  I2C 1 clock enable
+      I2C1EN         : APB1ENR_I2C1EN_Field := 16#0#;
+      --  I2C 2 clock enable
+      I2C2EN         : APB1ENR_I2C2EN_Field := 16#0#;
+      --  USB interface clock enable
+      USBRST         : APB1ENR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_27 : Interfaces.STM32.UInt4 := 16#0#;
+      --  Power interface clock enable
+      PWREN          : APB1ENR_PWREN_Field := 16#0#;
+      --  unspecified
+      Reserved_29_31 : Interfaces.STM32.UInt3 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1ENR_Register use record
+      Reserved_0_0   at 0 range 0 .. 0;
+      TIM3EN         at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6EN         at 0 range 4 .. 4;
+      TIM7EN         at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14EN        at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGEN         at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2EN         at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2EN       at 0 range 17 .. 17;
+      USART3EN       at 0 range 18 .. 18;
+      USART4EN       at 0 range 19 .. 19;
+      USART5EN       at 0 range 20 .. 20;
+      I2C1EN         at 0 range 21 .. 21;
+      I2C2EN         at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_27 at 0 range 24 .. 27;
+      PWREN          at 0 range 28 .. 28;
+      Reserved_29_31 at 0 range 29 .. 31;
+   end record;
+
+   subtype BDCR_LSEON_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSERDY_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEBYP_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEDRV_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCSEL_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCEN_Field is Interfaces.STM32.Bit;
+   subtype BDCR_BDRST_Field is Interfaces.STM32.Bit;
+
+   --  Backup domain control register (RCC_BDCR)
+   type BDCR_Register is record
+      --  External Low Speed oscillator enable
+      LSEON          : BDCR_LSEON_Field := 16#0#;
+      --  Read-only. External Low Speed oscillator ready
+      LSERDY         : BDCR_LSERDY_Field := 16#0#;
+      --  External Low Speed oscillator bypass
+      LSEBYP         : BDCR_LSEBYP_Field := 16#0#;
+      --  LSE oscillator drive capability
+      LSEDRV         : BDCR_LSEDRV_Field := 16#0#;
+      --  unspecified
+      Reserved_5_7   : Interfaces.STM32.UInt3 := 16#0#;
+      --  RTC clock source selection
+      RTCSEL         : BDCR_RTCSEL_Field := 16#0#;
+      --  unspecified
+      Reserved_10_14 : Interfaces.STM32.UInt5 := 16#0#;
+      --  RTC clock enable
+      RTCEN          : BDCR_RTCEN_Field := 16#0#;
+      --  Backup domain software reset
+      BDRST          : BDCR_BDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_17_31 : Interfaces.STM32.UInt15 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for BDCR_Register use record
+      LSEON          at 0 range 0 .. 0;
+      LSERDY         at 0 range 1 .. 1;
+      LSEBYP         at 0 range 2 .. 2;
+      LSEDRV         at 0 range 3 .. 4;
+      Reserved_5_7   at 0 range 5 .. 7;
+      RTCSEL         at 0 range 8 .. 9;
+      Reserved_10_14 at 0 range 10 .. 14;
+      RTCEN          at 0 range 15 .. 15;
+      BDRST          at 0 range 16 .. 16;
+      Reserved_17_31 at 0 range 17 .. 31;
+   end record;
+
+   subtype CSR_LSION_Field is Interfaces.STM32.Bit;
+   subtype CSR_LSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CSR_RMVF_Field is Interfaces.STM32.Bit;
+   subtype CSR_OBLRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PINRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PORRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_SFTRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_IWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_WWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_LPWRRSTF_Field is Interfaces.STM32.Bit;
+
+   --  Control/status register (RCC_CSR)
+   type CSR_Register is record
+      --  Internal low speed oscillator enable
+      LSION         : CSR_LSION_Field := 16#0#;
+      --  Read-only. Internal low speed oscillator ready
+      LSIRDY        : CSR_LSIRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_2_23 : Interfaces.STM32.UInt22 := 16#0#;
+      --  Remove reset flag
+      RMVF          : CSR_RMVF_Field := 16#0#;
+      --  Option byte loader reset flag
+      OBLRSTF       : CSR_OBLRSTF_Field := 16#0#;
+      --  PIN reset flag
+      PINRSTF       : CSR_PINRSTF_Field := 16#1#;
+      --  POR/PDR reset flag
+      PORRSTF       : CSR_PORRSTF_Field := 16#1#;
+      --  Software reset flag
+      SFTRSTF       : CSR_SFTRSTF_Field := 16#0#;
+      --  Independent watchdog reset flag
+      IWDGRSTF      : CSR_IWDGRSTF_Field := 16#0#;
+      --  Window watchdog reset flag
+      WWDGRSTF      : CSR_WWDGRSTF_Field := 16#0#;
+      --  Low-power reset flag
+      LPWRRSTF      : CSR_LPWRRSTF_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CSR_Register use record
+      LSION         at 0 range 0 .. 0;
+      LSIRDY        at 0 range 1 .. 1;
+      Reserved_2_23 at 0 range 2 .. 23;
+      RMVF          at 0 range 24 .. 24;
+      OBLRSTF       at 0 range 25 .. 25;
+      PINRSTF       at 0 range 26 .. 26;
+      PORRSTF       at 0 range 27 .. 27;
+      SFTRSTF       at 0 range 28 .. 28;
+      IWDGRSTF      at 0 range 29 .. 29;
+      WWDGRSTF      at 0 range 30 .. 30;
+      LPWRRSTF      at 0 range 31 .. 31;
+   end record;
+
+   subtype AHBRSTR_IOPARST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPBRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPCRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPDRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPFRST_Field is Interfaces.STM32.Bit;
+
+   --  AHB peripheral reset register
+   type AHBRSTR_Register is record
+      --  unspecified
+      Reserved_0_16  : Interfaces.STM32.UInt17 := 16#0#;
+      --  I/O port A reset
+      IOPARST        : AHBRSTR_IOPARST_Field := 16#0#;
+      --  I/O port B reset
+      IOPBRST        : AHBRSTR_IOPBRST_Field := 16#0#;
+      --  I/O port C reset
+      IOPCRST        : AHBRSTR_IOPCRST_Field := 16#0#;
+      --  I/O port D reset
+      IOPDRST        : AHBRSTR_IOPDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_21_21 : Interfaces.STM32.Bit := 16#0#;
+      --  I/O port F reset
+      IOPFRST        : AHBRSTR_IOPFRST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBRSTR_Register use record
+      Reserved_0_16  at 0 range 0 .. 16;
+      IOPARST        at 0 range 17 .. 17;
+      IOPBRST        at 0 range 18 .. 18;
+      IOPCRST        at 0 range 19 .. 19;
+      IOPDRST        at 0 range 20 .. 20;
+      Reserved_21_21 at 0 range 21 .. 21;
+      IOPFRST        at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype CFGR2_PREDIV_Field is Interfaces.STM32.UInt4;
+
+   --  Clock configuration register 2
+   type CFGR2_Register is record
+      --  PREDIV division factor
+      PREDIV        : CFGR2_PREDIV_Field := 16#0#;
+      --  unspecified
+      Reserved_4_31 : Interfaces.STM32.UInt28 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR2_Register use record
+      PREDIV        at 0 range 0 .. 3;
+      Reserved_4_31 at 0 range 4 .. 31;
+   end record;
+
+   subtype CFGR3_USART1SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR3_I2C1SW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_CECSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USBSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_ADCSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USART2SW_Field is Interfaces.STM32.UInt2;
+
+   --  Clock configuration register 3
+   type CFGR3_Register is record
+      --  USART1 clock source selection
+      USART1SW       : CFGR3_USART1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  I2C1 clock source selection
+      I2C1SW         : CFGR3_I2C1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  HDMI CEC clock source selection
+      CECSW          : CFGR3_CECSW_Field := 16#0#;
+      --  USB clock source selection
+      USBSW          : CFGR3_USBSW_Field := 16#0#;
+      --  ADC clock source selection
+      ADCSW          : CFGR3_ADCSW_Field := 16#0#;
+      --  unspecified
+      Reserved_9_15  : Interfaces.STM32.UInt7 := 16#0#;
+      --  USART2 clock source selection
+      USART2SW       : CFGR3_USART2SW_Field := 16#0#;
+      --  unspecified
+      Reserved_18_31 : Interfaces.STM32.UInt14 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR3_Register use record
+      USART1SW       at 0 range 0 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      I2C1SW         at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CECSW          at 0 range 6 .. 6;
+      USBSW          at 0 range 7 .. 7;
+      ADCSW          at 0 range 8 .. 8;
+      Reserved_9_15  at 0 range 9 .. 15;
+      USART2SW       at 0 range 16 .. 17;
+      Reserved_18_31 at 0 range 18 .. 31;
+   end record;
+
+   subtype CR2_HSI14ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14DIS_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14TRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR2_HSI14CAL_Field is Interfaces.STM32.Byte;
+   subtype CR2_HSI48ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48CAL_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register 2
+   type CR2_Register is record
+      --  HSI14 clock enable
+      HSI14ON        : CR2_HSI14ON_Field := 16#0#;
+      --  Read-only. HR14 clock ready flag
+      HSI14RDY       : CR2_HSI14RDY_Field := 16#0#;
+      --  HSI14 clock request from ADC disable
+      HSI14DIS       : CR2_HSI14DIS_Field := 16#0#;
+      --  HSI14 clock trimming
+      HSI14TRIM      : CR2_HSI14TRIM_Field := 16#10#;
+      --  Read-only. HSI14 clock calibration
+      HSI14CAL       : CR2_HSI14CAL_Field := 16#0#;
+      --  HSI48 clock enable
+      HSI48ON        : CR2_HSI48ON_Field := 16#0#;
+      --  Read-only. HSI48 clock ready flag
+      HSI48RDY       : CR2_HSI48RDY_Field := 16#0#;
+      --  unspecified
+      Reserved_18_23 : Interfaces.STM32.UInt6 := 16#0#;
+      --  Read-only. HSI48 factory clock calibration
+      HSI48CAL       : CR2_HSI48CAL_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR2_Register use record
+      HSI14ON        at 0 range 0 .. 0;
+      HSI14RDY       at 0 range 1 .. 1;
+      HSI14DIS       at 0 range 2 .. 2;
+      HSI14TRIM      at 0 range 3 .. 7;
+      HSI14CAL       at 0 range 8 .. 15;
+      HSI48ON        at 0 range 16 .. 16;
+      HSI48RDY       at 0 range 17 .. 17;
+      Reserved_18_23 at 0 range 18 .. 23;
+      HSI48CAL       at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Reset and clock control
+   type RCC_Peripheral is record
+      --  Clock control register
+      CR       : aliased CR_Register;
+      --  Clock configuration register (RCC_CFGR)
+      CFGR     : aliased CFGR_Register;
+      --  Clock interrupt register (RCC_CIR)
+      CIR      : aliased CIR_Register;
+      --  APB2 peripheral reset register (RCC_APB2RSTR)
+      APB2RSTR : aliased APB2RSTR_Register;
+      --  APB1 peripheral reset register (RCC_APB1RSTR)
+      APB1RSTR : aliased APB1RSTR_Register;
+      --  AHB Peripheral Clock enable register (RCC_AHBENR)
+      AHBENR   : aliased AHBENR_Register;
+      --  APB2 peripheral clock enable register (RCC_APB2ENR)
+      APB2ENR  : aliased APB2ENR_Register;
+      --  APB1 peripheral clock enable register (RCC_APB1ENR)
+      APB1ENR  : aliased APB1ENR_Register;
+      --  Backup domain control register (RCC_BDCR)
+      BDCR     : aliased BDCR_Register;
+      --  Control/status register (RCC_CSR)
+      CSR      : aliased CSR_Register;
+      --  AHB peripheral reset register
+      AHBRSTR  : aliased AHBRSTR_Register;
+      --  Clock configuration register 2
+      CFGR2    : aliased CFGR2_Register;
+      --  Clock configuration register 3
+      CFGR3    : aliased CFGR3_Register;
+      --  Clock control register 2
+      CR2      : aliased CR2_Register;
+   end record
+     with Volatile;
+
+   for RCC_Peripheral use record
+      CR       at 16#0# range 0 .. 31;
+      CFGR     at 16#4# range 0 .. 31;
+      CIR      at 16#8# range 0 .. 31;
+      APB2RSTR at 16#C# range 0 .. 31;
+      APB1RSTR at 16#10# range 0 .. 31;
+      AHBENR   at 16#14# range 0 .. 31;
+      APB2ENR  at 16#18# range 0 .. 31;
+      APB1ENR  at 16#1C# range 0 .. 31;
+      BDCR     at 16#20# range 0 .. 31;
+      CSR      at 16#24# range 0 .. 31;
+      AHBRSTR  at 16#28# range 0 .. 31;
+      CFGR2    at 16#2C# range 0 .. 31;
+      CFGR3    at 16#30# range 0 .. 31;
+      CR2      at 16#34# range 0 .. 31;
+   end record;
+
+   --  Reset and clock control
+   RCC_Periph : aliased RCC_Peripheral
+     with Import, Address => RCC_Base;
+
+end Interfaces.STM32.RCC;

--- a/arm/stm32/stm32f0xx/stm32f0x0/svd/i-stm32.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x0/svd/i-stm32.ads
@@ -1,0 +1,127 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x0.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+--  STM32F0x0
+package Interfaces.STM32 is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Base type --
+   ---------------
+
+   type UInt32 is new Interfaces.Unsigned_32;
+   type UInt16 is new Interfaces.Unsigned_16;
+   type Byte is new Interfaces.Unsigned_8;
+   type Bit is mod 2**1
+     with Size => 1;
+   type UInt2 is mod 2**2
+     with Size => 2;
+   type UInt3 is mod 2**3
+     with Size => 3;
+   type UInt4 is mod 2**4
+     with Size => 4;
+   type UInt5 is mod 2**5
+     with Size => 5;
+   type UInt6 is mod 2**6
+     with Size => 6;
+   type UInt7 is mod 2**7
+     with Size => 7;
+   type UInt9 is mod 2**9
+     with Size => 9;
+   type UInt10 is mod 2**10
+     with Size => 10;
+   type UInt11 is mod 2**11
+     with Size => 11;
+   type UInt12 is mod 2**12
+     with Size => 12;
+   type UInt13 is mod 2**13
+     with Size => 13;
+   type UInt14 is mod 2**14
+     with Size => 14;
+   type UInt15 is mod 2**15
+     with Size => 15;
+   type UInt17 is mod 2**17
+     with Size => 17;
+   type UInt18 is mod 2**18
+     with Size => 18;
+   type UInt19 is mod 2**19
+     with Size => 19;
+   type UInt20 is mod 2**20
+     with Size => 20;
+   type UInt21 is mod 2**21
+     with Size => 21;
+   type UInt22 is mod 2**22
+     with Size => 22;
+   type UInt23 is mod 2**23
+     with Size => 23;
+   type UInt24 is mod 2**24
+     with Size => 24;
+   type UInt25 is mod 2**25
+     with Size => 25;
+   type UInt26 is mod 2**26
+     with Size => 26;
+   type UInt27 is mod 2**27
+     with Size => 27;
+   type UInt28 is mod 2**28
+     with Size => 28;
+   type UInt29 is mod 2**29
+     with Size => 29;
+   type UInt30 is mod 2**30
+     with Size => 30;
+   type UInt31 is mod 2**31
+     with Size => 31;
+
+   --------------------
+   -- Base addresses --
+   --------------------
+
+   CRC_Base : constant System.Address := System'To_Address (16#40023000#);
+   GPIOF_Base : constant System.Address := System'To_Address (16#48001400#);
+   GPIOD_Base : constant System.Address := System'To_Address (16#48000C00#);
+   GPIOC_Base : constant System.Address := System'To_Address (16#48000800#);
+   GPIOB_Base : constant System.Address := System'To_Address (16#48000400#);
+   GPIOA_Base : constant System.Address := System'To_Address (16#48000000#);
+   SPI1_Base : constant System.Address := System'To_Address (16#40013000#);
+   SPI2_Base : constant System.Address := System'To_Address (16#40003800#);
+   PWR_Base : constant System.Address := System'To_Address (16#40007000#);
+   I2C1_Base : constant System.Address := System'To_Address (16#40005400#);
+   I2C2_Base : constant System.Address := System'To_Address (16#40005800#);
+   IWDG_Base : constant System.Address := System'To_Address (16#40003000#);
+   WWDG_Base : constant System.Address := System'To_Address (16#40002C00#);
+   TIM1_Base : constant System.Address := System'To_Address (16#40012C00#);
+   TIM3_Base : constant System.Address := System'To_Address (16#40000400#);
+   TIM14_Base : constant System.Address := System'To_Address (16#40002000#);
+   TIM6_Base : constant System.Address := System'To_Address (16#40001000#);
+   TIM7_Base : constant System.Address := System'To_Address (16#40001400#);
+   EXTI_Base : constant System.Address := System'To_Address (16#40010400#);
+   NVIC_Base : constant System.Address := System'To_Address (16#E000E100#);
+   DMA1_Base : constant System.Address := System'To_Address (16#40020000#);
+   RCC_Base : constant System.Address := System'To_Address (16#40021000#);
+   SYSCFG_Base : constant System.Address := System'To_Address (16#40010000#);
+   ADC_Base : constant System.Address := System'To_Address (16#40012400#);
+   USART1_Base : constant System.Address := System'To_Address (16#40013800#);
+   USART2_Base : constant System.Address := System'To_Address (16#40004400#);
+   USART3_Base : constant System.Address := System'To_Address (16#40004800#);
+   USART4_Base : constant System.Address := System'To_Address (16#40004C00#);
+   USART6_Base : constant System.Address := System'To_Address (16#40011400#);
+   USART5_Base : constant System.Address := System'To_Address (16#40005000#);
+   RTC_Base : constant System.Address := System'To_Address (16#40002800#);
+   TIM15_Base : constant System.Address := System'To_Address (16#40014000#);
+   TIM16_Base : constant System.Address := System'To_Address (16#40014400#);
+   TIM17_Base : constant System.Address := System'To_Address (16#40014800#);
+   Flash_Base : constant System.Address := System'To_Address (16#40022000#);
+   DBGMCU_Base : constant System.Address := System'To_Address (16#40015800#);
+   USB_Base : constant System.Address := System'To_Address (16#40005C00#);
+   SCB_Base : constant System.Address := System'To_Address (16#E000ED00#);
+   STK_Base : constant System.Address := System'To_Address (16#E000E010#);
+
+end Interfaces.STM32;

--- a/arm/stm32/stm32f0xx/stm32f0x1/svd/a-intnam.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x1/svd/a-intnam.ads
@@ -1,0 +1,117 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x1.svd
+
+--  This is a version for the STM32F0x1 MCU
+package Ada.Interrupts.Names is
+
+   --  All identifiers in this unit are implementation defined
+
+   pragma Implementation_Defined;
+
+   ----------------
+   -- Interrupts --
+   ----------------
+
+   --  System tick
+   Sys_Tick_Interrupt                     : constant Interrupt_ID := -1;
+
+   --  Window Watchdog interrupt
+   WWDG_Interrupt                         : constant Interrupt_ID := 0;
+
+   --  PVD and VDDIO2 supply comparator interrupt
+   PVD_Interrupt                          : constant Interrupt_ID := 1;
+
+   --  RTC interrupts
+   RTC_Interrupt                          : constant Interrupt_ID := 2;
+
+   --  Flash global interrupt
+   FLASH_Interrupt                        : constant Interrupt_ID := 3;
+
+   --  RCC and CRS global interrupts
+   RCC_CRS_Interrupt                      : constant Interrupt_ID := 4;
+
+   --  EXTI Line[1:0] interrupts
+   EXTI0_1_Interrupt                      : constant Interrupt_ID := 5;
+
+   --  EXTI Line[3:2] interrupts
+   EXTI2_3_Interrupt                      : constant Interrupt_ID := 6;
+
+   --  EXTI Line15 and EXTI4 interrupts
+   EXTI4_15_Interrupt                     : constant Interrupt_ID := 7;
+
+   --  Touch sensing interrupt
+   TSC_Interrupt                          : constant Interrupt_ID := 8;
+
+   --  DMA1 channel 1 interrupt
+   DMA1_CH1_Interrupt                     : constant Interrupt_ID := 9;
+
+   --  DMA1 channel 2 and 3 and DMA2 channel 1 and 2 interrupt
+   DMA1_CH2_3_DMA2_CH1_2_Interrupt        : constant Interrupt_ID := 10;
+
+   --  DMA1 channel 4, 5, 6 and 7 and DMA2 channel 3, 4 and 5 interrupts
+   DMA1_CH4_5_6_7_DMA2_CH3_4_5_Interrupt  : constant Interrupt_ID := 11;
+
+   --  ADC and comparator interrupts
+   ADC_COMP_Interrupt                     : constant Interrupt_ID := 12;
+
+   --  TIM1 break, update, trigger and commutation interrupt
+   TIM1_BRK_UP_TRG_COM_Interrupt          : constant Interrupt_ID := 13;
+
+   --  TIM1 Capture Compare interrupt
+   TIM1_CC_Interrupt                      : constant Interrupt_ID := 14;
+
+   --  TIM2 global interrupt
+   TIM2_Interrupt                         : constant Interrupt_ID := 15;
+
+   --  TIM3 global interrupt
+   TIM3_Interrupt                         : constant Interrupt_ID := 16;
+
+   --  TIM6 global interrupt and DAC underrun interrupt
+   TIM6_DAC_Interrupt                     : constant Interrupt_ID := 17;
+
+   --  TIM7 global interrupt
+   TIM7_Interrupt                         : constant Interrupt_ID := 18;
+
+   --  TIM14 global interrupt
+   TIM14_Interrupt                        : constant Interrupt_ID := 19;
+
+   --  TIM15 global interrupt
+   TIM15_Interrupt                        : constant Interrupt_ID := 20;
+
+   --  TIM16 global interrupt
+   TIM16_Interrupt                        : constant Interrupt_ID := 21;
+
+   --  TIM17 global interrupt
+   TIM17_Interrupt                        : constant Interrupt_ID := 22;
+
+   --  I2C1 global interrupt
+   I2C1_Interrupt                         : constant Interrupt_ID := 23;
+
+   --  I2C2 global interrupt
+   I2C2_Interrupt                         : constant Interrupt_ID := 24;
+
+   --  SPI1_global_interrupt
+   SPI1_Interrupt                         : constant Interrupt_ID := 25;
+
+   --  SPI2 global interrupt
+   SPI2_Interrupt                         : constant Interrupt_ID := 26;
+
+   --  USART1 global interrupt
+   USART1_Interrupt                       : constant Interrupt_ID := 27;
+
+   --  USART2 global interrupt
+   USART2_Interrupt                       : constant Interrupt_ID := 28;
+
+   --  USART3, USART4, USART5, USART6, USART7, USART8 global interrupt
+   USART3_4_5_6_7_8_Interrupt             : constant Interrupt_ID := 29;
+
+   --  CEC and CAN global interrupt
+   CEC_CAN_Interrupt                      : constant Interrupt_ID := 30;
+
+   --  USB global interrupt
+   USB_Interrupt                          : constant Interrupt_ID := 31;
+
+end Ada.Interrupts.Names;

--- a/arm/stm32/stm32f0xx/stm32f0x1/svd/i-stm32-flash.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x1/svd/i-stm32-flash.ads
@@ -1,0 +1,293 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x1.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.Flash is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype ACR_LATENCY_Field is Interfaces.STM32.UInt3;
+   subtype ACR_PRFTBE_Field is Interfaces.STM32.Bit;
+   subtype ACR_PRFTBS_Field is Interfaces.STM32.Bit;
+
+   --  Flash access control register
+   type ACR_Register is record
+      --  LATENCY
+      LATENCY       : ACR_LATENCY_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  PRFTBE
+      PRFTBE        : ACR_PRFTBE_Field := 16#1#;
+      --  Read-only. PRFTBS
+      PRFTBS        : ACR_PRFTBS_Field := 16#1#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for ACR_Register use record
+      LATENCY       at 0 range 0 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      PRFTBE        at 0 range 4 .. 4;
+      PRFTBS        at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype SR_BSY_Field is Interfaces.STM32.Bit;
+   subtype SR_PGERR_Field is Interfaces.STM32.Bit;
+   subtype SR_WRPRT_Field is Interfaces.STM32.Bit;
+   subtype SR_EOP_Field is Interfaces.STM32.Bit;
+
+   --  Flash status register
+   type SR_Register is record
+      --  Read-only. Busy
+      BSY           : SR_BSY_Field := 16#0#;
+      --  unspecified
+      Reserved_1_1  : Interfaces.STM32.Bit := 16#0#;
+      --  Programming error
+      PGERR         : SR_PGERR_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  Write protection error
+      WRPRT         : SR_WRPRT_Field := 16#0#;
+      --  End of operation
+      EOP           : SR_EOP_Field := 16#0#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for SR_Register use record
+      BSY           at 0 range 0 .. 0;
+      Reserved_1_1  at 0 range 1 .. 1;
+      PGERR         at 0 range 2 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      WRPRT         at 0 range 4 .. 4;
+      EOP           at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype CR_PG_Field is Interfaces.STM32.Bit;
+   subtype CR_PER_Field is Interfaces.STM32.Bit;
+   subtype CR_MER_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTPG_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTER_Field is Interfaces.STM32.Bit;
+   subtype CR_STRT_Field is Interfaces.STM32.Bit;
+   subtype CR_LOCK_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTWRE_Field is Interfaces.STM32.Bit;
+   subtype CR_ERRIE_Field is Interfaces.STM32.Bit;
+   subtype CR_EOPIE_Field is Interfaces.STM32.Bit;
+   subtype CR_FORCE_OPTLOAD_Field is Interfaces.STM32.Bit;
+
+   --  Flash control register
+   type CR_Register is record
+      --  Programming
+      PG             : CR_PG_Field := 16#0#;
+      --  Page erase
+      PER            : CR_PER_Field := 16#0#;
+      --  Mass erase
+      MER            : CR_MER_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  Option byte programming
+      OPTPG          : CR_OPTPG_Field := 16#0#;
+      --  Option byte erase
+      OPTER          : CR_OPTER_Field := 16#0#;
+      --  Start
+      STRT           : CR_STRT_Field := 16#0#;
+      --  Lock
+      LOCK           : CR_LOCK_Field := 16#1#;
+      --  unspecified
+      Reserved_8_8   : Interfaces.STM32.Bit := 16#0#;
+      --  Option bytes write enable
+      OPTWRE         : CR_OPTWRE_Field := 16#0#;
+      --  Error interrupt enable
+      ERRIE          : CR_ERRIE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_11 : Interfaces.STM32.Bit := 16#0#;
+      --  End of operation interrupt enable
+      EOPIE          : CR_EOPIE_Field := 16#0#;
+      --  Force option byte loading
+      FORCE_OPTLOAD  : CR_FORCE_OPTLOAD_Field := 16#0#;
+      --  unspecified
+      Reserved_14_31 : Interfaces.STM32.UInt18 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      PG             at 0 range 0 .. 0;
+      PER            at 0 range 1 .. 1;
+      MER            at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      OPTPG          at 0 range 4 .. 4;
+      OPTER          at 0 range 5 .. 5;
+      STRT           at 0 range 6 .. 6;
+      LOCK           at 0 range 7 .. 7;
+      Reserved_8_8   at 0 range 8 .. 8;
+      OPTWRE         at 0 range 9 .. 9;
+      ERRIE          at 0 range 10 .. 10;
+      Reserved_11_11 at 0 range 11 .. 11;
+      EOPIE          at 0 range 12 .. 12;
+      FORCE_OPTLOAD  at 0 range 13 .. 13;
+      Reserved_14_31 at 0 range 14 .. 31;
+   end record;
+
+   subtype OBR_OPTERR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RDPRT_Field is Interfaces.STM32.UInt2;
+   subtype OBR_WDG_SW_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STOP_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STDBY_Field is Interfaces.STM32.Bit;
+   --  OBR_nBOOT array element
+   subtype OBR_nBOOT_Element is Interfaces.STM32.Bit;
+
+   --  OBR_nBOOT array
+   type OBR_nBOOT_Field_Array is array (0 .. 1) of OBR_nBOOT_Element
+     with Component_Size => 1, Size => 2;
+
+   --  Type definition for OBR_nBOOT
+   type OBR_nBOOT_Field
+     (As_Array : Boolean := False)
+   is record
+      case As_Array is
+         when False =>
+            --  nBOOT as a value
+            Val : Interfaces.STM32.UInt2;
+         when True =>
+            --  nBOOT as an array
+            Arr : OBR_nBOOT_Field_Array;
+      end case;
+   end record
+     with Unchecked_Union, Size => 2;
+
+   for OBR_nBOOT_Field use record
+      Val at 0 range 0 .. 1;
+      Arr at 0 range 0 .. 1;
+   end record;
+
+   subtype OBR_VDDA_MONITOR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RAM_PARITY_CHECK_Field is Interfaces.STM32.Bit;
+   subtype OBR_BOOT_SEL_Field is Interfaces.STM32.Bit;
+   --  OBR_Data array element
+   subtype OBR_Data_Element is Interfaces.STM32.Byte;
+
+   --  OBR_Data array
+   type OBR_Data_Field_Array is array (0 .. 1) of OBR_Data_Element
+     with Component_Size => 8, Size => 16;
+
+   --  Type definition for OBR_Data
+   type OBR_Data_Field
+     (As_Array : Boolean := False)
+   is record
+      case As_Array is
+         when False =>
+            --  Data as a value
+            Val : Interfaces.STM32.UInt16;
+         when True =>
+            --  Data as an array
+            Arr : OBR_Data_Field_Array;
+      end case;
+   end record
+     with Unchecked_Union, Size => 16;
+
+   for OBR_Data_Field use record
+      Val at 0 range 0 .. 15;
+      Arr at 0 range 0 .. 15;
+   end record;
+
+   --  Option byte register
+   type OBR_Register is record
+      --  Read-only. Option byte error
+      OPTERR           : OBR_OPTERR_Field;
+      --  Read-only. Read protection level status
+      RDPRT            : OBR_RDPRT_Field;
+      --  unspecified
+      Reserved_3_7     : Interfaces.STM32.UInt5;
+      --  Read-only. WDG_SW
+      WDG_SW           : OBR_WDG_SW_Field;
+      --  Read-only. nRST_STOP
+      nRST_STOP        : OBR_nRST_STOP_Field;
+      --  Read-only. nRST_STDBY
+      nRST_STDBY       : OBR_nRST_STDBY_Field;
+      --  Read-only. nBOOT0
+      nBOOT            : OBR_nBOOT_Field;
+      --  Read-only. VDDA_MONITOR
+      VDDA_MONITOR     : OBR_VDDA_MONITOR_Field;
+      --  Read-only. RAM_PARITY_CHECK
+      RAM_PARITY_CHECK : OBR_RAM_PARITY_CHECK_Field;
+      --  Read-only. BOOT_SEL
+      BOOT_SEL         : OBR_BOOT_SEL_Field;
+      --  Read-only. Data0
+      Data             : OBR_Data_Field;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for OBR_Register use record
+      OPTERR           at 0 range 0 .. 0;
+      RDPRT            at 0 range 1 .. 2;
+      Reserved_3_7     at 0 range 3 .. 7;
+      WDG_SW           at 0 range 8 .. 8;
+      nRST_STOP        at 0 range 9 .. 9;
+      nRST_STDBY       at 0 range 10 .. 10;
+      nBOOT            at 0 range 11 .. 12;
+      VDDA_MONITOR     at 0 range 13 .. 13;
+      RAM_PARITY_CHECK at 0 range 14 .. 14;
+      BOOT_SEL         at 0 range 15 .. 15;
+      Data             at 0 range 16 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Flash
+   type Flash_Peripheral is record
+      --  Flash access control register
+      ACR     : aliased ACR_Register;
+      --  Flash key register
+      KEYR    : aliased Interfaces.STM32.UInt32;
+      --  Flash option key register
+      OPTKEYR : aliased Interfaces.STM32.UInt32;
+      --  Flash status register
+      SR      : aliased SR_Register;
+      --  Flash control register
+      CR      : aliased CR_Register;
+      --  Flash address register
+      AR      : aliased Interfaces.STM32.UInt32;
+      --  Option byte register
+      OBR     : aliased OBR_Register;
+      --  Write protection register
+      WRPR    : aliased Interfaces.STM32.UInt32;
+   end record
+     with Volatile;
+
+   for Flash_Peripheral use record
+      ACR     at 16#0# range 0 .. 31;
+      KEYR    at 16#4# range 0 .. 31;
+      OPTKEYR at 16#8# range 0 .. 31;
+      SR      at 16#C# range 0 .. 31;
+      CR      at 16#10# range 0 .. 31;
+      AR      at 16#14# range 0 .. 31;
+      OBR     at 16#1C# range 0 .. 31;
+      WRPR    at 16#20# range 0 .. 31;
+   end record;
+
+   --  Flash
+   Flash_Periph : aliased Flash_Peripheral
+     with Import, Address => Flash_Base;
+
+end Interfaces.STM32.Flash;

--- a/arm/stm32/stm32f0xx/stm32f0x1/svd/i-stm32-rcc.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x1/svd/i-stm32-rcc.ads
@@ -1,0 +1,1000 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x1.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.RCC is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype CR_HSION_Field is Interfaces.STM32.Bit;
+   subtype CR_HSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSITRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR_HSICAL_Field is Interfaces.STM32.Byte;
+   subtype CR_HSEON_Field is Interfaces.STM32.Bit;
+   subtype CR_HSERDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSEBYP_Field is Interfaces.STM32.Bit;
+   subtype CR_CSSON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLRDY_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register
+   type CR_Register is record
+      --  Internal High Speed clock enable
+      HSION          : CR_HSION_Field := 16#1#;
+      --  Read-only. Internal High Speed clock ready flag
+      HSIRDY         : CR_HSIRDY_Field := 16#1#;
+      --  unspecified
+      Reserved_2_2   : Interfaces.STM32.Bit := 16#0#;
+      --  Internal High Speed clock trimming
+      HSITRIM        : CR_HSITRIM_Field := 16#10#;
+      --  Read-only. Internal High Speed clock Calibration
+      HSICAL         : CR_HSICAL_Field := 16#0#;
+      --  External High Speed clock enable
+      HSEON          : CR_HSEON_Field := 16#0#;
+      --  Read-only. External High Speed clock ready flag
+      HSERDY         : CR_HSERDY_Field := 16#0#;
+      --  External High Speed clock Bypass
+      HSEBYP         : CR_HSEBYP_Field := 16#0#;
+      --  Clock Security System enable
+      CSSON          : CR_CSSON_Field := 16#0#;
+      --  unspecified
+      Reserved_20_23 : Interfaces.STM32.UInt4 := 16#0#;
+      --  PLL enable
+      PLLON          : CR_PLLON_Field := 16#0#;
+      --  Read-only. PLL clock ready flag
+      PLLRDY         : CR_PLLRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_26_31 : Interfaces.STM32.UInt6 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      HSION          at 0 range 0 .. 0;
+      HSIRDY         at 0 range 1 .. 1;
+      Reserved_2_2   at 0 range 2 .. 2;
+      HSITRIM        at 0 range 3 .. 7;
+      HSICAL         at 0 range 8 .. 15;
+      HSEON          at 0 range 16 .. 16;
+      HSERDY         at 0 range 17 .. 17;
+      HSEBYP         at 0 range 18 .. 18;
+      CSSON          at 0 range 19 .. 19;
+      Reserved_20_23 at 0 range 20 .. 23;
+      PLLON          at 0 range 24 .. 24;
+      PLLRDY         at 0 range 25 .. 25;
+      Reserved_26_31 at 0 range 26 .. 31;
+   end record;
+
+   subtype CFGR_SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_SWS_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_HPRE_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_PPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_ADCPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLSRC_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_PLLXTPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLMUL_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_MCO_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_MCOPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_PLLNODIV_Field is Interfaces.STM32.Bit;
+
+   --  Clock configuration register (RCC_CFGR)
+   type CFGR_Register is record
+      --  System clock Switch
+      SW             : CFGR_SW_Field := 16#0#;
+      --  Read-only. System Clock Switch Status
+      SWS            : CFGR_SWS_Field := 16#0#;
+      --  AHB prescaler
+      HPRE           : CFGR_HPRE_Field := 16#0#;
+      --  APB Low speed prescaler (APB1)
+      PPRE           : CFGR_PPRE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_13 : Interfaces.STM32.UInt3 := 16#0#;
+      --  ADC prescaler
+      ADCPRE         : CFGR_ADCPRE_Field := 16#0#;
+      --  PLL input clock source
+      PLLSRC         : CFGR_PLLSRC_Field := 16#0#;
+      --  HSE divider for PLL entry
+      PLLXTPRE       : CFGR_PLLXTPRE_Field := 16#0#;
+      --  PLL Multiplication Factor
+      PLLMUL         : CFGR_PLLMUL_Field := 16#0#;
+      --  unspecified
+      Reserved_22_23 : Interfaces.STM32.UInt2 := 16#0#;
+      --  Microcontroller clock output
+      MCO            : CFGR_MCO_Field := 16#0#;
+      --  unspecified
+      Reserved_27_27 : Interfaces.STM32.Bit := 16#0#;
+      --  Microcontroller Clock Output Prescaler
+      MCOPRE         : CFGR_MCOPRE_Field := 16#0#;
+      --  PLL clock not divided for MCO
+      PLLNODIV       : CFGR_PLLNODIV_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR_Register use record
+      SW             at 0 range 0 .. 1;
+      SWS            at 0 range 2 .. 3;
+      HPRE           at 0 range 4 .. 7;
+      PPRE           at 0 range 8 .. 10;
+      Reserved_11_13 at 0 range 11 .. 13;
+      ADCPRE         at 0 range 14 .. 14;
+      PLLSRC         at 0 range 15 .. 16;
+      PLLXTPRE       at 0 range 17 .. 17;
+      PLLMUL         at 0 range 18 .. 21;
+      Reserved_22_23 at 0 range 22 .. 23;
+      MCO            at 0 range 24 .. 26;
+      Reserved_27_27 at 0 range 27 .. 27;
+      MCOPRE         at 0 range 28 .. 30;
+      PLLNODIV       at 0 range 31 .. 31;
+   end record;
+
+   subtype CIR_LSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSC_Field is Interfaces.STM32.Bit;
+
+   --  Clock interrupt register (RCC_CIR)
+   type CIR_Register is record
+      --  Read-only. LSI Ready Interrupt flag
+      LSIRDYF        : CIR_LSIRDYF_Field := 16#0#;
+      --  Read-only. LSE Ready Interrupt flag
+      LSERDYF        : CIR_LSERDYF_Field := 16#0#;
+      --  Read-only. HSI Ready Interrupt flag
+      HSIRDYF        : CIR_HSIRDYF_Field := 16#0#;
+      --  Read-only. HSE Ready Interrupt flag
+      HSERDYF        : CIR_HSERDYF_Field := 16#0#;
+      --  Read-only. PLL Ready Interrupt flag
+      PLLRDYF        : CIR_PLLRDYF_Field := 16#0#;
+      --  Read-only. HSI14 ready interrupt flag
+      HSI14RDYF      : CIR_HSI14RDYF_Field := 16#0#;
+      --  Read-only. HSI48 ready interrupt flag
+      HSI48RDYF      : CIR_HSI48RDYF_Field := 16#0#;
+      --  Read-only. Clock Security System Interrupt flag
+      CSSF           : CIR_CSSF_Field := 16#0#;
+      --  LSI Ready Interrupt Enable
+      LSIRDYIE       : CIR_LSIRDYIE_Field := 16#0#;
+      --  LSE Ready Interrupt Enable
+      LSERDYIE       : CIR_LSERDYIE_Field := 16#0#;
+      --  HSI Ready Interrupt Enable
+      HSIRDYIE       : CIR_HSIRDYIE_Field := 16#0#;
+      --  HSE Ready Interrupt Enable
+      HSERDYIE       : CIR_HSERDYIE_Field := 16#0#;
+      --  PLL Ready Interrupt Enable
+      PLLRDYIE       : CIR_PLLRDYIE_Field := 16#0#;
+      --  HSI14 ready interrupt enable
+      HSI14RDYE      : CIR_HSI14RDYE_Field := 16#0#;
+      --  HSI48 ready interrupt enable
+      HSI48RDYIE     : CIR_HSI48RDYIE_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  Write-only. LSI Ready Interrupt Clear
+      LSIRDYC        : CIR_LSIRDYC_Field := 16#0#;
+      --  Write-only. LSE Ready Interrupt Clear
+      LSERDYC        : CIR_LSERDYC_Field := 16#0#;
+      --  Write-only. HSI Ready Interrupt Clear
+      HSIRDYC        : CIR_HSIRDYC_Field := 16#0#;
+      --  Write-only. HSE Ready Interrupt Clear
+      HSERDYC        : CIR_HSERDYC_Field := 16#0#;
+      --  Write-only. PLL Ready Interrupt Clear
+      PLLRDYC        : CIR_PLLRDYC_Field := 16#0#;
+      --  Write-only. HSI 14 MHz Ready Interrupt Clear
+      HSI14RDYC      : CIR_HSI14RDYC_Field := 16#0#;
+      --  Write-only. HSI48 Ready Interrupt Clear
+      HSI48RDYC      : CIR_HSI48RDYC_Field := 16#0#;
+      --  Write-only. Clock security system interrupt clear
+      CSSC           : CIR_CSSC_Field := 16#0#;
+      --  unspecified
+      Reserved_24_31 : Interfaces.STM32.Byte := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CIR_Register use record
+      LSIRDYF        at 0 range 0 .. 0;
+      LSERDYF        at 0 range 1 .. 1;
+      HSIRDYF        at 0 range 2 .. 2;
+      HSERDYF        at 0 range 3 .. 3;
+      PLLRDYF        at 0 range 4 .. 4;
+      HSI14RDYF      at 0 range 5 .. 5;
+      HSI48RDYF      at 0 range 6 .. 6;
+      CSSF           at 0 range 7 .. 7;
+      LSIRDYIE       at 0 range 8 .. 8;
+      LSERDYIE       at 0 range 9 .. 9;
+      HSIRDYIE       at 0 range 10 .. 10;
+      HSERDYIE       at 0 range 11 .. 11;
+      PLLRDYIE       at 0 range 12 .. 12;
+      HSI14RDYE      at 0 range 13 .. 13;
+      HSI48RDYIE     at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      LSIRDYC        at 0 range 16 .. 16;
+      LSERDYC        at 0 range 17 .. 17;
+      HSIRDYC        at 0 range 18 .. 18;
+      HSERDYC        at 0 range 19 .. 19;
+      PLLRDYC        at 0 range 20 .. 20;
+      HSI14RDYC      at 0 range 21 .. 21;
+      HSI48RDYC      at 0 range 22 .. 22;
+      CSSC           at 0 range 23 .. 23;
+      Reserved_24_31 at 0 range 24 .. 31;
+   end record;
+
+   subtype APB2RSTR_SYSCFGRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_ADCRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_SPI1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_USART1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM15RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM16RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM17RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_DBGMCURST_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral reset register (RCC_APB2RSTR)
+   type APB2RSTR_Register is record
+      --  SYSCFG and COMP reset
+      SYSCFGRST      : APB2RSTR_SYSCFGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_1_8   : Interfaces.STM32.Byte := 16#0#;
+      --  ADC interface reset
+      ADCRST         : APB2RSTR_ADCRST_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 timer reset
+      TIM1RST        : APB2RSTR_TIM1RST_Field := 16#0#;
+      --  SPI 1 reset
+      SPI1RST        : APB2RSTR_SPI1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 reset
+      USART1RST      : APB2RSTR_USART1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer reset
+      TIM15RST       : APB2RSTR_TIM15RST_Field := 16#0#;
+      --  TIM16 timer reset
+      TIM16RST       : APB2RSTR_TIM16RST_Field := 16#0#;
+      --  TIM17 timer reset
+      TIM17RST       : APB2RSTR_TIM17RST_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  Debug MCU reset
+      DBGMCURST      : APB2RSTR_DBGMCURST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2RSTR_Register use record
+      SYSCFGRST      at 0 range 0 .. 0;
+      Reserved_1_8   at 0 range 1 .. 8;
+      ADCRST         at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1RST        at 0 range 11 .. 11;
+      SPI1RST        at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1RST      at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15RST       at 0 range 16 .. 16;
+      TIM16RST       at 0 range 17 .. 17;
+      TIM17RST       at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCURST      at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1RSTR_TIM2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM6RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM7RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM14RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_WWDGRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_SPI2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART4RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART5RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C1RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CANRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CRSRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_PWRRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_DACRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CECRST_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral reset register (RCC_APB1RSTR)
+   type APB1RSTR_Register is record
+      --  Timer 2 reset
+      TIM2RST        : APB1RSTR_TIM2RST_Field := 16#0#;
+      --  Timer 3 reset
+      TIM3RST        : APB1RSTR_TIM3RST_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 reset
+      TIM6RST        : APB1RSTR_TIM6RST_Field := 16#0#;
+      --  TIM7 timer reset
+      TIM7RST        : APB1RSTR_TIM7RST_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 reset
+      TIM14RST       : APB1RSTR_TIM14RST_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog reset
+      WWDGRST        : APB1RSTR_WWDGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI2 reset
+      SPI2RST        : APB1RSTR_SPI2RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 reset
+      USART2RST      : APB1RSTR_USART2RST_Field := 16#0#;
+      --  USART3 reset
+      USART3RST      : APB1RSTR_USART3RST_Field := 16#0#;
+      --  USART4 reset
+      USART4RST      : APB1RSTR_USART4RST_Field := 16#0#;
+      --  USART5 reset
+      USART5RST      : APB1RSTR_USART5RST_Field := 16#0#;
+      --  I2C1 reset
+      I2C1RST        : APB1RSTR_I2C1RST_Field := 16#0#;
+      --  I2C2 reset
+      I2C2RST        : APB1RSTR_I2C2RST_Field := 16#0#;
+      --  USB interface reset
+      USBRST         : APB1RSTR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_24 : Interfaces.STM32.Bit := 16#0#;
+      --  CAN interface reset
+      CANRST         : APB1RSTR_CANRST_Field := 16#0#;
+      --  unspecified
+      Reserved_26_26 : Interfaces.STM32.Bit := 16#0#;
+      --  Clock Recovery System interface reset
+      CRSRST         : APB1RSTR_CRSRST_Field := 16#0#;
+      --  Power interface reset
+      PWRRST         : APB1RSTR_PWRRST_Field := 16#0#;
+      --  DAC interface reset
+      DACRST         : APB1RSTR_DACRST_Field := 16#0#;
+      --  HDMI CEC reset
+      CECRST         : APB1RSTR_CECRST_Field := 16#0#;
+      --  unspecified
+      Reserved_31_31 : Interfaces.STM32.Bit := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1RSTR_Register use record
+      TIM2RST        at 0 range 0 .. 0;
+      TIM3RST        at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6RST        at 0 range 4 .. 4;
+      TIM7RST        at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14RST       at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGRST        at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2RST        at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2RST      at 0 range 17 .. 17;
+      USART3RST      at 0 range 18 .. 18;
+      USART4RST      at 0 range 19 .. 19;
+      USART5RST      at 0 range 20 .. 20;
+      I2C1RST        at 0 range 21 .. 21;
+      I2C2RST        at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_24 at 0 range 24 .. 24;
+      CANRST         at 0 range 25 .. 25;
+      Reserved_26_26 at 0 range 26 .. 26;
+      CRSRST         at 0 range 27 .. 27;
+      PWRRST         at 0 range 28 .. 28;
+      DACRST         at 0 range 29 .. 29;
+      CECRST         at 0 range 30 .. 30;
+      Reserved_31_31 at 0 range 31 .. 31;
+   end record;
+
+   subtype AHBENR_DMA1EN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_DMA2EN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_SRAMEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_FLITFEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_CRCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPAEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPBEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPDEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPFEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_TSCEN_Field is Interfaces.STM32.Bit;
+
+   --  AHB Peripheral Clock enable register (RCC_AHBENR)
+   type AHBENR_Register is record
+      --  DMA1 clock enable
+      DMA1EN         : AHBENR_DMA1EN_Field := 16#0#;
+      --  DMA2 clock enable
+      DMA2EN         : AHBENR_DMA2EN_Field := 16#0#;
+      --  SRAM interface clock enable
+      SRAMEN         : AHBENR_SRAMEN_Field := 16#1#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  FLITF clock enable
+      FLITFEN        : AHBENR_FLITFEN_Field := 16#1#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  CRC clock enable
+      CRCEN          : AHBENR_CRCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_7_16  : Interfaces.STM32.UInt10 := 16#0#;
+      --  I/O port A clock enable
+      IOPAEN         : AHBENR_IOPAEN_Field := 16#0#;
+      --  I/O port B clock enable
+      IOPBEN         : AHBENR_IOPBEN_Field := 16#0#;
+      --  I/O port C clock enable
+      IOPCEN         : AHBENR_IOPCEN_Field := 16#0#;
+      --  I/O port D clock enable
+      IOPDEN         : AHBENR_IOPDEN_Field := 16#0#;
+      --  unspecified
+      Reserved_21_21 : Interfaces.STM32.Bit := 16#0#;
+      --  I/O port F clock enable
+      IOPFEN         : AHBENR_IOPFEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_23 : Interfaces.STM32.Bit := 16#0#;
+      --  Touch sensing controller clock enable
+      TSCEN          : AHBENR_TSCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBENR_Register use record
+      DMA1EN         at 0 range 0 .. 0;
+      DMA2EN         at 0 range 1 .. 1;
+      SRAMEN         at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      FLITFEN        at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CRCEN          at 0 range 6 .. 6;
+      Reserved_7_16  at 0 range 7 .. 16;
+      IOPAEN         at 0 range 17 .. 17;
+      IOPBEN         at 0 range 18 .. 18;
+      IOPCEN         at 0 range 19 .. 19;
+      IOPDEN         at 0 range 20 .. 20;
+      Reserved_21_21 at 0 range 21 .. 21;
+      IOPFEN         at 0 range 22 .. 22;
+      Reserved_23_23 at 0 range 23 .. 23;
+      TSCEN          at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   subtype APB2ENR_SYSCFGEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_USART6EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_USART7EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_USART8EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_ADCEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_SPI1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_USART1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM15EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM16EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM17EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_DBGMCUEN_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral clock enable register (RCC_APB2ENR)
+   type APB2ENR_Register is record
+      --  SYSCFG clock enable
+      SYSCFGEN       : APB2ENR_SYSCFGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_1_4   : Interfaces.STM32.UInt4 := 16#0#;
+      --  USART6 clock enable
+      USART6EN       : APB2ENR_USART6EN_Field := 16#0#;
+      --  USART7 clock enable
+      USART7EN       : APB2ENR_USART7EN_Field := 16#0#;
+      --  USART8 clock enable
+      USART8EN       : APB2ENR_USART8EN_Field := 16#0#;
+      --  unspecified
+      Reserved_8_8   : Interfaces.STM32.Bit := 16#0#;
+      --  ADC 1 interface clock enable
+      ADCEN          : APB2ENR_ADCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 Timer clock enable
+      TIM1EN         : APB2ENR_TIM1EN_Field := 16#0#;
+      --  SPI 1 clock enable
+      SPI1EN         : APB2ENR_SPI1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 clock enable
+      USART1EN       : APB2ENR_USART1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer clock enable
+      TIM15EN        : APB2ENR_TIM15EN_Field := 16#0#;
+      --  TIM16 timer clock enable
+      TIM16EN        : APB2ENR_TIM16EN_Field := 16#0#;
+      --  TIM17 timer clock enable
+      TIM17EN        : APB2ENR_TIM17EN_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  MCU debug module clock enable
+      DBGMCUEN       : APB2ENR_DBGMCUEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2ENR_Register use record
+      SYSCFGEN       at 0 range 0 .. 0;
+      Reserved_1_4   at 0 range 1 .. 4;
+      USART6EN       at 0 range 5 .. 5;
+      USART7EN       at 0 range 6 .. 6;
+      USART8EN       at 0 range 7 .. 7;
+      Reserved_8_8   at 0 range 8 .. 8;
+      ADCEN          at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1EN         at 0 range 11 .. 11;
+      SPI1EN         at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1EN       at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15EN        at 0 range 16 .. 16;
+      TIM16EN        at 0 range 17 .. 17;
+      TIM17EN        at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCUEN       at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1ENR_TIM2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM6EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM7EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM14EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_WWDGEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_SPI2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART4EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART5EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C1EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CANEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CRSEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_PWREN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_DACEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CECEN_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral clock enable register (RCC_APB1ENR)
+   type APB1ENR_Register is record
+      --  Timer 2 clock enable
+      TIM2EN         : APB1ENR_TIM2EN_Field := 16#0#;
+      --  Timer 3 clock enable
+      TIM3EN         : APB1ENR_TIM3EN_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 clock enable
+      TIM6EN         : APB1ENR_TIM6EN_Field := 16#0#;
+      --  TIM7 timer clock enable
+      TIM7EN         : APB1ENR_TIM7EN_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 clock enable
+      TIM14EN        : APB1ENR_TIM14EN_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog clock enable
+      WWDGEN         : APB1ENR_WWDGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI 2 clock enable
+      SPI2EN         : APB1ENR_SPI2EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 clock enable
+      USART2EN       : APB1ENR_USART2EN_Field := 16#0#;
+      --  USART3 clock enable
+      USART3EN       : APB1ENR_USART3EN_Field := 16#0#;
+      --  USART4 clock enable
+      USART4EN       : APB1ENR_USART4EN_Field := 16#0#;
+      --  USART5 clock enable
+      USART5EN       : APB1ENR_USART5EN_Field := 16#0#;
+      --  I2C 1 clock enable
+      I2C1EN         : APB1ENR_I2C1EN_Field := 16#0#;
+      --  I2C 2 clock enable
+      I2C2EN         : APB1ENR_I2C2EN_Field := 16#0#;
+      --  USB interface clock enable
+      USBRST         : APB1ENR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_24 : Interfaces.STM32.Bit := 16#0#;
+      --  CAN interface clock enable
+      CANEN          : APB1ENR_CANEN_Field := 16#0#;
+      --  unspecified
+      Reserved_26_26 : Interfaces.STM32.Bit := 16#0#;
+      --  Clock Recovery System interface clock enable
+      CRSEN          : APB1ENR_CRSEN_Field := 16#0#;
+      --  Power interface clock enable
+      PWREN          : APB1ENR_PWREN_Field := 16#0#;
+      --  DAC interface clock enable
+      DACEN          : APB1ENR_DACEN_Field := 16#0#;
+      --  HDMI CEC interface clock enable
+      CECEN          : APB1ENR_CECEN_Field := 16#0#;
+      --  unspecified
+      Reserved_31_31 : Interfaces.STM32.Bit := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1ENR_Register use record
+      TIM2EN         at 0 range 0 .. 0;
+      TIM3EN         at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6EN         at 0 range 4 .. 4;
+      TIM7EN         at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14EN        at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGEN         at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2EN         at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2EN       at 0 range 17 .. 17;
+      USART3EN       at 0 range 18 .. 18;
+      USART4EN       at 0 range 19 .. 19;
+      USART5EN       at 0 range 20 .. 20;
+      I2C1EN         at 0 range 21 .. 21;
+      I2C2EN         at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_24 at 0 range 24 .. 24;
+      CANEN          at 0 range 25 .. 25;
+      Reserved_26_26 at 0 range 26 .. 26;
+      CRSEN          at 0 range 27 .. 27;
+      PWREN          at 0 range 28 .. 28;
+      DACEN          at 0 range 29 .. 29;
+      CECEN          at 0 range 30 .. 30;
+      Reserved_31_31 at 0 range 31 .. 31;
+   end record;
+
+   subtype BDCR_LSEON_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSERDY_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEBYP_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEDRV_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCSEL_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCEN_Field is Interfaces.STM32.Bit;
+   subtype BDCR_BDRST_Field is Interfaces.STM32.Bit;
+
+   --  Backup domain control register (RCC_BDCR)
+   type BDCR_Register is record
+      --  External Low Speed oscillator enable
+      LSEON          : BDCR_LSEON_Field := 16#0#;
+      --  Read-only. External Low Speed oscillator ready
+      LSERDY         : BDCR_LSERDY_Field := 16#0#;
+      --  External Low Speed oscillator bypass
+      LSEBYP         : BDCR_LSEBYP_Field := 16#0#;
+      --  LSE oscillator drive capability
+      LSEDRV         : BDCR_LSEDRV_Field := 16#0#;
+      --  unspecified
+      Reserved_5_7   : Interfaces.STM32.UInt3 := 16#0#;
+      --  RTC clock source selection
+      RTCSEL         : BDCR_RTCSEL_Field := 16#0#;
+      --  unspecified
+      Reserved_10_14 : Interfaces.STM32.UInt5 := 16#0#;
+      --  RTC clock enable
+      RTCEN          : BDCR_RTCEN_Field := 16#0#;
+      --  Backup domain software reset
+      BDRST          : BDCR_BDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_17_31 : Interfaces.STM32.UInt15 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for BDCR_Register use record
+      LSEON          at 0 range 0 .. 0;
+      LSERDY         at 0 range 1 .. 1;
+      LSEBYP         at 0 range 2 .. 2;
+      LSEDRV         at 0 range 3 .. 4;
+      Reserved_5_7   at 0 range 5 .. 7;
+      RTCSEL         at 0 range 8 .. 9;
+      Reserved_10_14 at 0 range 10 .. 14;
+      RTCEN          at 0 range 15 .. 15;
+      BDRST          at 0 range 16 .. 16;
+      Reserved_17_31 at 0 range 17 .. 31;
+   end record;
+
+   subtype CSR_LSION_Field is Interfaces.STM32.Bit;
+   subtype CSR_LSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CSR_RMVF_Field is Interfaces.STM32.Bit;
+   subtype CSR_OBLRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PINRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PORRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_SFTRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_IWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_WWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_LPWRRSTF_Field is Interfaces.STM32.Bit;
+
+   --  Control/status register (RCC_CSR)
+   type CSR_Register is record
+      --  Internal low speed oscillator enable
+      LSION         : CSR_LSION_Field := 16#0#;
+      --  Read-only. Internal low speed oscillator ready
+      LSIRDY        : CSR_LSIRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_2_23 : Interfaces.STM32.UInt22 := 16#0#;
+      --  Remove reset flag
+      RMVF          : CSR_RMVF_Field := 16#0#;
+      --  Option byte loader reset flag
+      OBLRSTF       : CSR_OBLRSTF_Field := 16#0#;
+      --  PIN reset flag
+      PINRSTF       : CSR_PINRSTF_Field := 16#1#;
+      --  POR/PDR reset flag
+      PORRSTF       : CSR_PORRSTF_Field := 16#1#;
+      --  Software reset flag
+      SFTRSTF       : CSR_SFTRSTF_Field := 16#0#;
+      --  Independent watchdog reset flag
+      IWDGRSTF      : CSR_IWDGRSTF_Field := 16#0#;
+      --  Window watchdog reset flag
+      WWDGRSTF      : CSR_WWDGRSTF_Field := 16#0#;
+      --  Low-power reset flag
+      LPWRRSTF      : CSR_LPWRRSTF_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CSR_Register use record
+      LSION         at 0 range 0 .. 0;
+      LSIRDY        at 0 range 1 .. 1;
+      Reserved_2_23 at 0 range 2 .. 23;
+      RMVF          at 0 range 24 .. 24;
+      OBLRSTF       at 0 range 25 .. 25;
+      PINRSTF       at 0 range 26 .. 26;
+      PORRSTF       at 0 range 27 .. 27;
+      SFTRSTF       at 0 range 28 .. 28;
+      IWDGRSTF      at 0 range 29 .. 29;
+      WWDGRSTF      at 0 range 30 .. 30;
+      LPWRRSTF      at 0 range 31 .. 31;
+   end record;
+
+   subtype AHBRSTR_IOPARST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPBRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPCRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPDRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPFRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_TSCRST_Field is Interfaces.STM32.Bit;
+
+   --  AHB peripheral reset register
+   type AHBRSTR_Register is record
+      --  unspecified
+      Reserved_0_16  : Interfaces.STM32.UInt17 := 16#0#;
+      --  I/O port A reset
+      IOPARST        : AHBRSTR_IOPARST_Field := 16#0#;
+      --  I/O port B reset
+      IOPBRST        : AHBRSTR_IOPBRST_Field := 16#0#;
+      --  I/O port C reset
+      IOPCRST        : AHBRSTR_IOPCRST_Field := 16#0#;
+      --  I/O port D reset
+      IOPDRST        : AHBRSTR_IOPDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_21_21 : Interfaces.STM32.Bit := 16#0#;
+      --  I/O port F reset
+      IOPFRST        : AHBRSTR_IOPFRST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_23 : Interfaces.STM32.Bit := 16#0#;
+      --  Touch sensing controller reset
+      TSCRST         : AHBRSTR_TSCRST_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBRSTR_Register use record
+      Reserved_0_16  at 0 range 0 .. 16;
+      IOPARST        at 0 range 17 .. 17;
+      IOPBRST        at 0 range 18 .. 18;
+      IOPCRST        at 0 range 19 .. 19;
+      IOPDRST        at 0 range 20 .. 20;
+      Reserved_21_21 at 0 range 21 .. 21;
+      IOPFRST        at 0 range 22 .. 22;
+      Reserved_23_23 at 0 range 23 .. 23;
+      TSCRST         at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   subtype CFGR2_PREDIV_Field is Interfaces.STM32.UInt4;
+
+   --  Clock configuration register 2
+   type CFGR2_Register is record
+      --  PREDIV division factor
+      PREDIV        : CFGR2_PREDIV_Field := 16#0#;
+      --  unspecified
+      Reserved_4_31 : Interfaces.STM32.UInt28 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR2_Register use record
+      PREDIV        at 0 range 0 .. 3;
+      Reserved_4_31 at 0 range 4 .. 31;
+   end record;
+
+   subtype CFGR3_USART1SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR3_I2C1SW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_CECSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USBSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_ADCSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USART2SW_Field is Interfaces.STM32.UInt2;
+
+   --  Clock configuration register 3
+   type CFGR3_Register is record
+      --  USART1 clock source selection
+      USART1SW       : CFGR3_USART1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  I2C1 clock source selection
+      I2C1SW         : CFGR3_I2C1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  HDMI CEC clock source selection
+      CECSW          : CFGR3_CECSW_Field := 16#0#;
+      --  USB clock source selection
+      USBSW          : CFGR3_USBSW_Field := 16#0#;
+      --  ADC clock source selection
+      ADCSW          : CFGR3_ADCSW_Field := 16#0#;
+      --  unspecified
+      Reserved_9_15  : Interfaces.STM32.UInt7 := 16#0#;
+      --  USART2 clock source selection
+      USART2SW       : CFGR3_USART2SW_Field := 16#0#;
+      --  unspecified
+      Reserved_18_31 : Interfaces.STM32.UInt14 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR3_Register use record
+      USART1SW       at 0 range 0 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      I2C1SW         at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CECSW          at 0 range 6 .. 6;
+      USBSW          at 0 range 7 .. 7;
+      ADCSW          at 0 range 8 .. 8;
+      Reserved_9_15  at 0 range 9 .. 15;
+      USART2SW       at 0 range 16 .. 17;
+      Reserved_18_31 at 0 range 18 .. 31;
+   end record;
+
+   subtype CR2_HSI14ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14DIS_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14TRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR2_HSI14CAL_Field is Interfaces.STM32.Byte;
+   subtype CR2_HSI48ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48CAL_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register 2
+   type CR2_Register is record
+      --  HSI14 clock enable
+      HSI14ON        : CR2_HSI14ON_Field := 16#0#;
+      --  Read-only. HR14 clock ready flag
+      HSI14RDY       : CR2_HSI14RDY_Field := 16#0#;
+      --  HSI14 clock request from ADC disable
+      HSI14DIS       : CR2_HSI14DIS_Field := 16#0#;
+      --  HSI14 clock trimming
+      HSI14TRIM      : CR2_HSI14TRIM_Field := 16#10#;
+      --  Read-only. HSI14 clock calibration
+      HSI14CAL       : CR2_HSI14CAL_Field := 16#0#;
+      --  HSI48 clock enable
+      HSI48ON        : CR2_HSI48ON_Field := 16#0#;
+      --  Read-only. HSI48 clock ready flag
+      HSI48RDY       : CR2_HSI48RDY_Field := 16#0#;
+      --  unspecified
+      Reserved_18_23 : Interfaces.STM32.UInt6 := 16#0#;
+      --  Read-only. HSI48 factory clock calibration
+      HSI48CAL       : CR2_HSI48CAL_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR2_Register use record
+      HSI14ON        at 0 range 0 .. 0;
+      HSI14RDY       at 0 range 1 .. 1;
+      HSI14DIS       at 0 range 2 .. 2;
+      HSI14TRIM      at 0 range 3 .. 7;
+      HSI14CAL       at 0 range 8 .. 15;
+      HSI48ON        at 0 range 16 .. 16;
+      HSI48RDY       at 0 range 17 .. 17;
+      Reserved_18_23 at 0 range 18 .. 23;
+      HSI48CAL       at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Reset and clock control
+   type RCC_Peripheral is record
+      --  Clock control register
+      CR       : aliased CR_Register;
+      --  Clock configuration register (RCC_CFGR)
+      CFGR     : aliased CFGR_Register;
+      --  Clock interrupt register (RCC_CIR)
+      CIR      : aliased CIR_Register;
+      --  APB2 peripheral reset register (RCC_APB2RSTR)
+      APB2RSTR : aliased APB2RSTR_Register;
+      --  APB1 peripheral reset register (RCC_APB1RSTR)
+      APB1RSTR : aliased APB1RSTR_Register;
+      --  AHB Peripheral Clock enable register (RCC_AHBENR)
+      AHBENR   : aliased AHBENR_Register;
+      --  APB2 peripheral clock enable register (RCC_APB2ENR)
+      APB2ENR  : aliased APB2ENR_Register;
+      --  APB1 peripheral clock enable register (RCC_APB1ENR)
+      APB1ENR  : aliased APB1ENR_Register;
+      --  Backup domain control register (RCC_BDCR)
+      BDCR     : aliased BDCR_Register;
+      --  Control/status register (RCC_CSR)
+      CSR      : aliased CSR_Register;
+      --  AHB peripheral reset register
+      AHBRSTR  : aliased AHBRSTR_Register;
+      --  Clock configuration register 2
+      CFGR2    : aliased CFGR2_Register;
+      --  Clock configuration register 3
+      CFGR3    : aliased CFGR3_Register;
+      --  Clock control register 2
+      CR2      : aliased CR2_Register;
+   end record
+     with Volatile;
+
+   for RCC_Peripheral use record
+      CR       at 16#0# range 0 .. 31;
+      CFGR     at 16#4# range 0 .. 31;
+      CIR      at 16#8# range 0 .. 31;
+      APB2RSTR at 16#C# range 0 .. 31;
+      APB1RSTR at 16#10# range 0 .. 31;
+      AHBENR   at 16#14# range 0 .. 31;
+      APB2ENR  at 16#18# range 0 .. 31;
+      APB1ENR  at 16#1C# range 0 .. 31;
+      BDCR     at 16#20# range 0 .. 31;
+      CSR      at 16#24# range 0 .. 31;
+      AHBRSTR  at 16#28# range 0 .. 31;
+      CFGR2    at 16#2C# range 0 .. 31;
+      CFGR3    at 16#30# range 0 .. 31;
+      CR2      at 16#34# range 0 .. 31;
+   end record;
+
+   --  Reset and clock control
+   RCC_Periph : aliased RCC_Peripheral
+     with Import, Address => RCC_Base;
+
+end Interfaces.STM32.RCC;

--- a/arm/stm32/stm32f0xx/stm32f0x1/svd/i-stm32.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x1/svd/i-stm32.ads
@@ -1,0 +1,137 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x1.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+--  STM32F0x1
+package Interfaces.STM32 is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Base type --
+   ---------------
+
+   type UInt32 is new Interfaces.Unsigned_32;
+   type UInt16 is new Interfaces.Unsigned_16;
+   type Byte is new Interfaces.Unsigned_8;
+   type Bit is mod 2**1
+     with Size => 1;
+   type UInt2 is mod 2**2
+     with Size => 2;
+   type UInt3 is mod 2**3
+     with Size => 3;
+   type UInt4 is mod 2**4
+     with Size => 4;
+   type UInt5 is mod 2**5
+     with Size => 5;
+   type UInt6 is mod 2**6
+     with Size => 6;
+   type UInt7 is mod 2**7
+     with Size => 7;
+   type UInt9 is mod 2**9
+     with Size => 9;
+   type UInt10 is mod 2**10
+     with Size => 10;
+   type UInt11 is mod 2**11
+     with Size => 11;
+   type UInt12 is mod 2**12
+     with Size => 12;
+   type UInt13 is mod 2**13
+     with Size => 13;
+   type UInt14 is mod 2**14
+     with Size => 14;
+   type UInt15 is mod 2**15
+     with Size => 15;
+   type UInt17 is mod 2**17
+     with Size => 17;
+   type UInt18 is mod 2**18
+     with Size => 18;
+   type UInt19 is mod 2**19
+     with Size => 19;
+   type UInt20 is mod 2**20
+     with Size => 20;
+   type UInt21 is mod 2**21
+     with Size => 21;
+   type UInt22 is mod 2**22
+     with Size => 22;
+   type UInt23 is mod 2**23
+     with Size => 23;
+   type UInt24 is mod 2**24
+     with Size => 24;
+   type UInt25 is mod 2**25
+     with Size => 25;
+   type UInt26 is mod 2**26
+     with Size => 26;
+   type UInt27 is mod 2**27
+     with Size => 27;
+   type UInt28 is mod 2**28
+     with Size => 28;
+   type UInt29 is mod 2**29
+     with Size => 29;
+   type UInt30 is mod 2**30
+     with Size => 30;
+   type UInt31 is mod 2**31
+     with Size => 31;
+
+   --------------------
+   -- Base addresses --
+   --------------------
+
+   CRC_Base : constant System.Address := System'To_Address (16#40023000#);
+   GPIOF_Base : constant System.Address := System'To_Address (16#48001400#);
+   GPIOD_Base : constant System.Address := System'To_Address (16#48000C00#);
+   GPIOC_Base : constant System.Address := System'To_Address (16#48000800#);
+   GPIOB_Base : constant System.Address := System'To_Address (16#48000400#);
+   GPIOE_Base : constant System.Address := System'To_Address (16#48001000#);
+   GPIOA_Base : constant System.Address := System'To_Address (16#48000000#);
+   SPI1_Base : constant System.Address := System'To_Address (16#40013000#);
+   SPI2_Base : constant System.Address := System'To_Address (16#40003800#);
+   PWR_Base : constant System.Address := System'To_Address (16#40007000#);
+   I2C1_Base : constant System.Address := System'To_Address (16#40005400#);
+   I2C2_Base : constant System.Address := System'To_Address (16#40005800#);
+   IWDG_Base : constant System.Address := System'To_Address (16#40003000#);
+   WWDG_Base : constant System.Address := System'To_Address (16#40002C00#);
+   TIM1_Base : constant System.Address := System'To_Address (16#40012C00#);
+   TIM2_Base : constant System.Address := System'To_Address (16#40000000#);
+   TIM3_Base : constant System.Address := System'To_Address (16#40000400#);
+   TIM14_Base : constant System.Address := System'To_Address (16#40002000#);
+   TIM6_Base : constant System.Address := System'To_Address (16#40001000#);
+   TIM7_Base : constant System.Address := System'To_Address (16#40001400#);
+   EXTI_Base : constant System.Address := System'To_Address (16#40010400#);
+   NVIC_Base : constant System.Address := System'To_Address (16#E000E100#);
+   DMA1_Base : constant System.Address := System'To_Address (16#40020000#);
+   DMA2_Base : constant System.Address := System'To_Address (16#40020400#);
+   RCC_Base : constant System.Address := System'To_Address (16#40021000#);
+   SYSCFG_COMP_Base : constant System.Address := System'To_Address (16#40010000#);
+   ADC_Base : constant System.Address := System'To_Address (16#40012400#);
+   USART1_Base : constant System.Address := System'To_Address (16#40013800#);
+   USART2_Base : constant System.Address := System'To_Address (16#40004400#);
+   USART3_Base : constant System.Address := System'To_Address (16#40004800#);
+   USART4_Base : constant System.Address := System'To_Address (16#40004C00#);
+   USART6_Base : constant System.Address := System'To_Address (16#40011400#);
+   USART7_Base : constant System.Address := System'To_Address (16#40011800#);
+   USART8_Base : constant System.Address := System'To_Address (16#40011C00#);
+   USART5_Base : constant System.Address := System'To_Address (16#40005000#);
+   RTC_Base : constant System.Address := System'To_Address (16#40002800#);
+   TIM15_Base : constant System.Address := System'To_Address (16#40014000#);
+   TIM16_Base : constant System.Address := System'To_Address (16#40014400#);
+   TIM17_Base : constant System.Address := System'To_Address (16#40014800#);
+   TSC_Base : constant System.Address := System'To_Address (16#40024000#);
+   CEC_Base : constant System.Address := System'To_Address (16#40007800#);
+   Flash_Base : constant System.Address := System'To_Address (16#40022000#);
+   DBGMCU_Base : constant System.Address := System'To_Address (16#40015800#);
+   USB_Base : constant System.Address := System'To_Address (16#40005C00#);
+   CRS_Base : constant System.Address := System'To_Address (16#40006C00#);
+   CAN_Base : constant System.Address := System'To_Address (16#40006400#);
+   DAC_Base : constant System.Address := System'To_Address (16#40007400#);
+   SCB_Base : constant System.Address := System'To_Address (16#E000ED00#);
+   STK_Base : constant System.Address := System'To_Address (16#E000E010#);
+
+end Interfaces.STM32;

--- a/arm/stm32/stm32f0xx/stm32f0x2/svd/a-intnam.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x2/svd/a-intnam.ads
@@ -1,0 +1,111 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x2.svd
+
+--  This is a version for the STM32F0x2 MCU
+package Ada.Interrupts.Names is
+
+   --  All identifiers in this unit are implementation defined
+
+   pragma Implementation_Defined;
+
+   ----------------
+   -- Interrupts --
+   ----------------
+
+   --  System tick
+   Sys_Tick_Interrupt             : constant Interrupt_ID := -1;
+
+   --  Window Watchdog interrupt
+   WWDG_Interrupt                 : constant Interrupt_ID := 0;
+
+   --  PVD and VDDIO2 supply comparator interrupt
+   PVD_Interrupt                  : constant Interrupt_ID := 1;
+
+   --  RTC interrupts
+   RTC_Interrupt                  : constant Interrupt_ID := 2;
+
+   --  Flash global interrupt
+   FLASH_Interrupt                : constant Interrupt_ID := 3;
+
+   --  RCC and CRS global interrupts
+   RCC_CRS_Interrupt              : constant Interrupt_ID := 4;
+
+   --  EXTI Line[1:0] interrupts
+   EXTI0_1_Interrupt              : constant Interrupt_ID := 5;
+
+   --  EXTI Line[3:2] interrupts
+   EXTI2_3_Interrupt              : constant Interrupt_ID := 6;
+
+   --  EXTI Line15 and EXTI4 interrupts
+   EXTI4_15_Interrupt             : constant Interrupt_ID := 7;
+
+   --  Touch sensing interrupt
+   TSC_Interrupt                  : constant Interrupt_ID := 8;
+
+   --  DMA1 channel 1 interrupt
+   DMA1_CH1_Interrupt             : constant Interrupt_ID := 9;
+
+   --  ADC and comparator interrupts
+   ADC_COMP_Interrupt             : constant Interrupt_ID := 12;
+
+   --  TIM1 break, update, trigger and commutation interrupt
+   TIM1_BRK_UP_TRG_COM_Interrupt  : constant Interrupt_ID := 13;
+
+   --  TIM1 Capture Compare interrupt
+   TIM1_CC_Interrupt              : constant Interrupt_ID := 14;
+
+   --  TIM2 global interrupt
+   TIM2_Interrupt                 : constant Interrupt_ID := 15;
+
+   --  TIM3 global interrupt
+   TIM3_Interrupt                 : constant Interrupt_ID := 16;
+
+   --  TIM6 global interrupt and DAC underrun interrupt
+   TIM6_DAC_Interrupt             : constant Interrupt_ID := 17;
+
+   --  TIM7 global interrupt
+   TIM7_Interrupt                 : constant Interrupt_ID := 18;
+
+   --  TIM14 global interrupt
+   TIM14_Interrupt                : constant Interrupt_ID := 19;
+
+   --  TIM15 global interrupt
+   TIM15_Interrupt                : constant Interrupt_ID := 20;
+
+   --  TIM16 global interrupt
+   TIM16_Interrupt                : constant Interrupt_ID := 21;
+
+   --  TIM17 global interrupt
+   TIM17_Interrupt                : constant Interrupt_ID := 22;
+
+   --  I2C1 global interrupt
+   I2C1_Interrupt                 : constant Interrupt_ID := 23;
+
+   --  I2C2 global interrupt
+   I2C2_Interrupt                 : constant Interrupt_ID := 24;
+
+   --  SPI1_global_interrupt
+   SPI1_Interrupt                 : constant Interrupt_ID := 25;
+
+   --  SPI2 global interrupt
+   SPI2_Interrupt                 : constant Interrupt_ID := 26;
+
+   --  USART1 global interrupt
+   USART1_Interrupt               : constant Interrupt_ID := 27;
+
+   --  USART2 global interrupt
+   USART2_Interrupt               : constant Interrupt_ID := 28;
+
+   --  USART3 and USART4 global interrupt
+   USART3_4_Interrupt             : constant Interrupt_ID := 29;
+
+   --  CEC and CAN global interrupt
+   CEC_CAN_Interrupt              : constant Interrupt_ID := 30;
+
+   --  USB global interrupt
+   USB_Interrupt                  : constant Interrupt_ID := 31;
+
+end Ada.Interrupts.Names;

--- a/arm/stm32/stm32f0xx/stm32f0x2/svd/i-stm32-flash.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x2/svd/i-stm32-flash.ads
@@ -1,0 +1,293 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x2.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.Flash is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype ACR_LATENCY_Field is Interfaces.STM32.UInt3;
+   subtype ACR_PRFTBE_Field is Interfaces.STM32.Bit;
+   subtype ACR_PRFTBS_Field is Interfaces.STM32.Bit;
+
+   --  Flash access control register
+   type ACR_Register is record
+      --  LATENCY
+      LATENCY       : ACR_LATENCY_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  PRFTBE
+      PRFTBE        : ACR_PRFTBE_Field := 16#1#;
+      --  Read-only. PRFTBS
+      PRFTBS        : ACR_PRFTBS_Field := 16#1#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for ACR_Register use record
+      LATENCY       at 0 range 0 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      PRFTBE        at 0 range 4 .. 4;
+      PRFTBS        at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype SR_BSY_Field is Interfaces.STM32.Bit;
+   subtype SR_PGERR_Field is Interfaces.STM32.Bit;
+   subtype SR_WRPRT_Field is Interfaces.STM32.Bit;
+   subtype SR_EOP_Field is Interfaces.STM32.Bit;
+
+   --  Flash status register
+   type SR_Register is record
+      --  Read-only. Busy
+      BSY           : SR_BSY_Field := 16#0#;
+      --  unspecified
+      Reserved_1_1  : Interfaces.STM32.Bit := 16#0#;
+      --  Programming error
+      PGERR         : SR_PGERR_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  Write protection error
+      WRPRT         : SR_WRPRT_Field := 16#0#;
+      --  End of operation
+      EOP           : SR_EOP_Field := 16#0#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for SR_Register use record
+      BSY           at 0 range 0 .. 0;
+      Reserved_1_1  at 0 range 1 .. 1;
+      PGERR         at 0 range 2 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      WRPRT         at 0 range 4 .. 4;
+      EOP           at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype CR_PG_Field is Interfaces.STM32.Bit;
+   subtype CR_PER_Field is Interfaces.STM32.Bit;
+   subtype CR_MER_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTPG_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTER_Field is Interfaces.STM32.Bit;
+   subtype CR_STRT_Field is Interfaces.STM32.Bit;
+   subtype CR_LOCK_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTWRE_Field is Interfaces.STM32.Bit;
+   subtype CR_ERRIE_Field is Interfaces.STM32.Bit;
+   subtype CR_EOPIE_Field is Interfaces.STM32.Bit;
+   subtype CR_FORCE_OPTLOAD_Field is Interfaces.STM32.Bit;
+
+   --  Flash control register
+   type CR_Register is record
+      --  Programming
+      PG             : CR_PG_Field := 16#0#;
+      --  Page erase
+      PER            : CR_PER_Field := 16#0#;
+      --  Mass erase
+      MER            : CR_MER_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  Option byte programming
+      OPTPG          : CR_OPTPG_Field := 16#0#;
+      --  Option byte erase
+      OPTER          : CR_OPTER_Field := 16#0#;
+      --  Start
+      STRT           : CR_STRT_Field := 16#0#;
+      --  Lock
+      LOCK           : CR_LOCK_Field := 16#1#;
+      --  unspecified
+      Reserved_8_8   : Interfaces.STM32.Bit := 16#0#;
+      --  Option bytes write enable
+      OPTWRE         : CR_OPTWRE_Field := 16#0#;
+      --  Error interrupt enable
+      ERRIE          : CR_ERRIE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_11 : Interfaces.STM32.Bit := 16#0#;
+      --  End of operation interrupt enable
+      EOPIE          : CR_EOPIE_Field := 16#0#;
+      --  Force option byte loading
+      FORCE_OPTLOAD  : CR_FORCE_OPTLOAD_Field := 16#0#;
+      --  unspecified
+      Reserved_14_31 : Interfaces.STM32.UInt18 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      PG             at 0 range 0 .. 0;
+      PER            at 0 range 1 .. 1;
+      MER            at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      OPTPG          at 0 range 4 .. 4;
+      OPTER          at 0 range 5 .. 5;
+      STRT           at 0 range 6 .. 6;
+      LOCK           at 0 range 7 .. 7;
+      Reserved_8_8   at 0 range 8 .. 8;
+      OPTWRE         at 0 range 9 .. 9;
+      ERRIE          at 0 range 10 .. 10;
+      Reserved_11_11 at 0 range 11 .. 11;
+      EOPIE          at 0 range 12 .. 12;
+      FORCE_OPTLOAD  at 0 range 13 .. 13;
+      Reserved_14_31 at 0 range 14 .. 31;
+   end record;
+
+   subtype OBR_OPTERR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RDPRT_Field is Interfaces.STM32.UInt2;
+   subtype OBR_WDG_SW_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STOP_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STDBY_Field is Interfaces.STM32.Bit;
+   --  OBR_nBOOT array element
+   subtype OBR_nBOOT_Element is Interfaces.STM32.Bit;
+
+   --  OBR_nBOOT array
+   type OBR_nBOOT_Field_Array is array (0 .. 1) of OBR_nBOOT_Element
+     with Component_Size => 1, Size => 2;
+
+   --  Type definition for OBR_nBOOT
+   type OBR_nBOOT_Field
+     (As_Array : Boolean := False)
+   is record
+      case As_Array is
+         when False =>
+            --  nBOOT as a value
+            Val : Interfaces.STM32.UInt2;
+         when True =>
+            --  nBOOT as an array
+            Arr : OBR_nBOOT_Field_Array;
+      end case;
+   end record
+     with Unchecked_Union, Size => 2;
+
+   for OBR_nBOOT_Field use record
+      Val at 0 range 0 .. 1;
+      Arr at 0 range 0 .. 1;
+   end record;
+
+   subtype OBR_VDDA_MONITOR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RAM_PARITY_CHECK_Field is Interfaces.STM32.Bit;
+   subtype OBR_BOOT_SEL_Field is Interfaces.STM32.Bit;
+   --  OBR_Data array element
+   subtype OBR_Data_Element is Interfaces.STM32.Byte;
+
+   --  OBR_Data array
+   type OBR_Data_Field_Array is array (0 .. 1) of OBR_Data_Element
+     with Component_Size => 8, Size => 16;
+
+   --  Type definition for OBR_Data
+   type OBR_Data_Field
+     (As_Array : Boolean := False)
+   is record
+      case As_Array is
+         when False =>
+            --  Data as a value
+            Val : Interfaces.STM32.UInt16;
+         when True =>
+            --  Data as an array
+            Arr : OBR_Data_Field_Array;
+      end case;
+   end record
+     with Unchecked_Union, Size => 16;
+
+   for OBR_Data_Field use record
+      Val at 0 range 0 .. 15;
+      Arr at 0 range 0 .. 15;
+   end record;
+
+   --  Option byte register
+   type OBR_Register is record
+      --  Read-only. Option byte error
+      OPTERR           : OBR_OPTERR_Field;
+      --  Read-only. Read protection level status
+      RDPRT            : OBR_RDPRT_Field;
+      --  unspecified
+      Reserved_3_7     : Interfaces.STM32.UInt5;
+      --  Read-only. WDG_SW
+      WDG_SW           : OBR_WDG_SW_Field;
+      --  Read-only. nRST_STOP
+      nRST_STOP        : OBR_nRST_STOP_Field;
+      --  Read-only. nRST_STDBY
+      nRST_STDBY       : OBR_nRST_STDBY_Field;
+      --  Read-only. nBOOT0
+      nBOOT            : OBR_nBOOT_Field;
+      --  Read-only. VDDA_MONITOR
+      VDDA_MONITOR     : OBR_VDDA_MONITOR_Field;
+      --  Read-only. RAM_PARITY_CHECK
+      RAM_PARITY_CHECK : OBR_RAM_PARITY_CHECK_Field;
+      --  Read-only. BOOT_SEL
+      BOOT_SEL         : OBR_BOOT_SEL_Field;
+      --  Read-only. Data0
+      Data             : OBR_Data_Field;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for OBR_Register use record
+      OPTERR           at 0 range 0 .. 0;
+      RDPRT            at 0 range 1 .. 2;
+      Reserved_3_7     at 0 range 3 .. 7;
+      WDG_SW           at 0 range 8 .. 8;
+      nRST_STOP        at 0 range 9 .. 9;
+      nRST_STDBY       at 0 range 10 .. 10;
+      nBOOT            at 0 range 11 .. 12;
+      VDDA_MONITOR     at 0 range 13 .. 13;
+      RAM_PARITY_CHECK at 0 range 14 .. 14;
+      BOOT_SEL         at 0 range 15 .. 15;
+      Data             at 0 range 16 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Flash
+   type Flash_Peripheral is record
+      --  Flash access control register
+      ACR     : aliased ACR_Register;
+      --  Flash key register
+      KEYR    : aliased Interfaces.STM32.UInt32;
+      --  Flash option key register
+      OPTKEYR : aliased Interfaces.STM32.UInt32;
+      --  Flash status register
+      SR      : aliased SR_Register;
+      --  Flash control register
+      CR      : aliased CR_Register;
+      --  Flash address register
+      AR      : aliased Interfaces.STM32.UInt32;
+      --  Option byte register
+      OBR     : aliased OBR_Register;
+      --  Write protection register
+      WRPR    : aliased Interfaces.STM32.UInt32;
+   end record
+     with Volatile;
+
+   for Flash_Peripheral use record
+      ACR     at 16#0# range 0 .. 31;
+      KEYR    at 16#4# range 0 .. 31;
+      OPTKEYR at 16#8# range 0 .. 31;
+      SR      at 16#C# range 0 .. 31;
+      CR      at 16#10# range 0 .. 31;
+      AR      at 16#14# range 0 .. 31;
+      OBR     at 16#1C# range 0 .. 31;
+      WRPR    at 16#20# range 0 .. 31;
+   end record;
+
+   --  Flash
+   Flash_Periph : aliased Flash_Peripheral
+     with Import, Address => Flash_Base;
+
+end Interfaces.STM32.Flash;

--- a/arm/stm32/stm32f0xx/stm32f0x2/svd/i-stm32-rcc.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x2/svd/i-stm32-rcc.ads
@@ -1,0 +1,982 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x2.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.RCC is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype CR_HSION_Field is Interfaces.STM32.Bit;
+   subtype CR_HSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSITRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR_HSICAL_Field is Interfaces.STM32.Byte;
+   subtype CR_HSEON_Field is Interfaces.STM32.Bit;
+   subtype CR_HSERDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSEBYP_Field is Interfaces.STM32.Bit;
+   subtype CR_CSSON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLRDY_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register
+   type CR_Register is record
+      --  Internal High Speed clock enable
+      HSION          : CR_HSION_Field := 16#1#;
+      --  Read-only. Internal High Speed clock ready flag
+      HSIRDY         : CR_HSIRDY_Field := 16#1#;
+      --  unspecified
+      Reserved_2_2   : Interfaces.STM32.Bit := 16#0#;
+      --  Internal High Speed clock trimming
+      HSITRIM        : CR_HSITRIM_Field := 16#10#;
+      --  Read-only. Internal High Speed clock Calibration
+      HSICAL         : CR_HSICAL_Field := 16#0#;
+      --  External High Speed clock enable
+      HSEON          : CR_HSEON_Field := 16#0#;
+      --  Read-only. External High Speed clock ready flag
+      HSERDY         : CR_HSERDY_Field := 16#0#;
+      --  External High Speed clock Bypass
+      HSEBYP         : CR_HSEBYP_Field := 16#0#;
+      --  Clock Security System enable
+      CSSON          : CR_CSSON_Field := 16#0#;
+      --  unspecified
+      Reserved_20_23 : Interfaces.STM32.UInt4 := 16#0#;
+      --  PLL enable
+      PLLON          : CR_PLLON_Field := 16#0#;
+      --  Read-only. PLL clock ready flag
+      PLLRDY         : CR_PLLRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_26_31 : Interfaces.STM32.UInt6 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      HSION          at 0 range 0 .. 0;
+      HSIRDY         at 0 range 1 .. 1;
+      Reserved_2_2   at 0 range 2 .. 2;
+      HSITRIM        at 0 range 3 .. 7;
+      HSICAL         at 0 range 8 .. 15;
+      HSEON          at 0 range 16 .. 16;
+      HSERDY         at 0 range 17 .. 17;
+      HSEBYP         at 0 range 18 .. 18;
+      CSSON          at 0 range 19 .. 19;
+      Reserved_20_23 at 0 range 20 .. 23;
+      PLLON          at 0 range 24 .. 24;
+      PLLRDY         at 0 range 25 .. 25;
+      Reserved_26_31 at 0 range 26 .. 31;
+   end record;
+
+   subtype CFGR_SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_SWS_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_HPRE_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_PPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_ADCPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLSRC_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_PLLXTPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLMUL_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_MCO_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_MCOPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_PLLNODIV_Field is Interfaces.STM32.Bit;
+
+   --  Clock configuration register (RCC_CFGR)
+   type CFGR_Register is record
+      --  System clock Switch
+      SW             : CFGR_SW_Field := 16#0#;
+      --  Read-only. System Clock Switch Status
+      SWS            : CFGR_SWS_Field := 16#0#;
+      --  AHB prescaler
+      HPRE           : CFGR_HPRE_Field := 16#0#;
+      --  APB Low speed prescaler (APB1)
+      PPRE           : CFGR_PPRE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_13 : Interfaces.STM32.UInt3 := 16#0#;
+      --  ADC prescaler
+      ADCPRE         : CFGR_ADCPRE_Field := 16#0#;
+      --  PLL input clock source
+      PLLSRC         : CFGR_PLLSRC_Field := 16#0#;
+      --  HSE divider for PLL entry
+      PLLXTPRE       : CFGR_PLLXTPRE_Field := 16#0#;
+      --  PLL Multiplication Factor
+      PLLMUL         : CFGR_PLLMUL_Field := 16#0#;
+      --  unspecified
+      Reserved_22_23 : Interfaces.STM32.UInt2 := 16#0#;
+      --  Microcontroller clock output
+      MCO            : CFGR_MCO_Field := 16#0#;
+      --  unspecified
+      Reserved_27_27 : Interfaces.STM32.Bit := 16#0#;
+      --  Microcontroller Clock Output Prescaler
+      MCOPRE         : CFGR_MCOPRE_Field := 16#0#;
+      --  PLL clock not divided for MCO
+      PLLNODIV       : CFGR_PLLNODIV_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR_Register use record
+      SW             at 0 range 0 .. 1;
+      SWS            at 0 range 2 .. 3;
+      HPRE           at 0 range 4 .. 7;
+      PPRE           at 0 range 8 .. 10;
+      Reserved_11_13 at 0 range 11 .. 13;
+      ADCPRE         at 0 range 14 .. 14;
+      PLLSRC         at 0 range 15 .. 16;
+      PLLXTPRE       at 0 range 17 .. 17;
+      PLLMUL         at 0 range 18 .. 21;
+      Reserved_22_23 at 0 range 22 .. 23;
+      MCO            at 0 range 24 .. 26;
+      Reserved_27_27 at 0 range 27 .. 27;
+      MCOPRE         at 0 range 28 .. 30;
+      PLLNODIV       at 0 range 31 .. 31;
+   end record;
+
+   subtype CIR_LSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSC_Field is Interfaces.STM32.Bit;
+
+   --  Clock interrupt register (RCC_CIR)
+   type CIR_Register is record
+      --  Read-only. LSI Ready Interrupt flag
+      LSIRDYF        : CIR_LSIRDYF_Field := 16#0#;
+      --  Read-only. LSE Ready Interrupt flag
+      LSERDYF        : CIR_LSERDYF_Field := 16#0#;
+      --  Read-only. HSI Ready Interrupt flag
+      HSIRDYF        : CIR_HSIRDYF_Field := 16#0#;
+      --  Read-only. HSE Ready Interrupt flag
+      HSERDYF        : CIR_HSERDYF_Field := 16#0#;
+      --  Read-only. PLL Ready Interrupt flag
+      PLLRDYF        : CIR_PLLRDYF_Field := 16#0#;
+      --  Read-only. HSI14 ready interrupt flag
+      HSI14RDYF      : CIR_HSI14RDYF_Field := 16#0#;
+      --  Read-only. HSI48 ready interrupt flag
+      HSI48RDYF      : CIR_HSI48RDYF_Field := 16#0#;
+      --  Read-only. Clock Security System Interrupt flag
+      CSSF           : CIR_CSSF_Field := 16#0#;
+      --  LSI Ready Interrupt Enable
+      LSIRDYIE       : CIR_LSIRDYIE_Field := 16#0#;
+      --  LSE Ready Interrupt Enable
+      LSERDYIE       : CIR_LSERDYIE_Field := 16#0#;
+      --  HSI Ready Interrupt Enable
+      HSIRDYIE       : CIR_HSIRDYIE_Field := 16#0#;
+      --  HSE Ready Interrupt Enable
+      HSERDYIE       : CIR_HSERDYIE_Field := 16#0#;
+      --  PLL Ready Interrupt Enable
+      PLLRDYIE       : CIR_PLLRDYIE_Field := 16#0#;
+      --  HSI14 ready interrupt enable
+      HSI14RDYE      : CIR_HSI14RDYE_Field := 16#0#;
+      --  HSI48 ready interrupt enable
+      HSI48RDYIE     : CIR_HSI48RDYIE_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  Write-only. LSI Ready Interrupt Clear
+      LSIRDYC        : CIR_LSIRDYC_Field := 16#0#;
+      --  Write-only. LSE Ready Interrupt Clear
+      LSERDYC        : CIR_LSERDYC_Field := 16#0#;
+      --  Write-only. HSI Ready Interrupt Clear
+      HSIRDYC        : CIR_HSIRDYC_Field := 16#0#;
+      --  Write-only. HSE Ready Interrupt Clear
+      HSERDYC        : CIR_HSERDYC_Field := 16#0#;
+      --  Write-only. PLL Ready Interrupt Clear
+      PLLRDYC        : CIR_PLLRDYC_Field := 16#0#;
+      --  Write-only. HSI 14 MHz Ready Interrupt Clear
+      HSI14RDYC      : CIR_HSI14RDYC_Field := 16#0#;
+      --  Write-only. HSI48 Ready Interrupt Clear
+      HSI48RDYC      : CIR_HSI48RDYC_Field := 16#0#;
+      --  Write-only. Clock security system interrupt clear
+      CSSC           : CIR_CSSC_Field := 16#0#;
+      --  unspecified
+      Reserved_24_31 : Interfaces.STM32.Byte := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CIR_Register use record
+      LSIRDYF        at 0 range 0 .. 0;
+      LSERDYF        at 0 range 1 .. 1;
+      HSIRDYF        at 0 range 2 .. 2;
+      HSERDYF        at 0 range 3 .. 3;
+      PLLRDYF        at 0 range 4 .. 4;
+      HSI14RDYF      at 0 range 5 .. 5;
+      HSI48RDYF      at 0 range 6 .. 6;
+      CSSF           at 0 range 7 .. 7;
+      LSIRDYIE       at 0 range 8 .. 8;
+      LSERDYIE       at 0 range 9 .. 9;
+      HSIRDYIE       at 0 range 10 .. 10;
+      HSERDYIE       at 0 range 11 .. 11;
+      PLLRDYIE       at 0 range 12 .. 12;
+      HSI14RDYE      at 0 range 13 .. 13;
+      HSI48RDYIE     at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      LSIRDYC        at 0 range 16 .. 16;
+      LSERDYC        at 0 range 17 .. 17;
+      HSIRDYC        at 0 range 18 .. 18;
+      HSERDYC        at 0 range 19 .. 19;
+      PLLRDYC        at 0 range 20 .. 20;
+      HSI14RDYC      at 0 range 21 .. 21;
+      HSI48RDYC      at 0 range 22 .. 22;
+      CSSC           at 0 range 23 .. 23;
+      Reserved_24_31 at 0 range 24 .. 31;
+   end record;
+
+   subtype APB2RSTR_SYSCFGRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_ADCRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_SPI1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_USART1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM15RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM16RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM17RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_DBGMCURST_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral reset register (RCC_APB2RSTR)
+   type APB2RSTR_Register is record
+      --  SYSCFG and COMP reset
+      SYSCFGRST      : APB2RSTR_SYSCFGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_1_8   : Interfaces.STM32.Byte := 16#0#;
+      --  ADC interface reset
+      ADCRST         : APB2RSTR_ADCRST_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 timer reset
+      TIM1RST        : APB2RSTR_TIM1RST_Field := 16#0#;
+      --  SPI 1 reset
+      SPI1RST        : APB2RSTR_SPI1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 reset
+      USART1RST      : APB2RSTR_USART1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer reset
+      TIM15RST       : APB2RSTR_TIM15RST_Field := 16#0#;
+      --  TIM16 timer reset
+      TIM16RST       : APB2RSTR_TIM16RST_Field := 16#0#;
+      --  TIM17 timer reset
+      TIM17RST       : APB2RSTR_TIM17RST_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  Debug MCU reset
+      DBGMCURST      : APB2RSTR_DBGMCURST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2RSTR_Register use record
+      SYSCFGRST      at 0 range 0 .. 0;
+      Reserved_1_8   at 0 range 1 .. 8;
+      ADCRST         at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1RST        at 0 range 11 .. 11;
+      SPI1RST        at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1RST      at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15RST       at 0 range 16 .. 16;
+      TIM16RST       at 0 range 17 .. 17;
+      TIM17RST       at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCURST      at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1RSTR_TIM2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM6RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM7RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM14RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_WWDGRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_SPI2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART4RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C1RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CANRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CRSRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_PWRRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_DACRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CECRST_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral reset register (RCC_APB1RSTR)
+   type APB1RSTR_Register is record
+      --  Timer 2 reset
+      TIM2RST        : APB1RSTR_TIM2RST_Field := 16#0#;
+      --  Timer 3 reset
+      TIM3RST        : APB1RSTR_TIM3RST_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 reset
+      TIM6RST        : APB1RSTR_TIM6RST_Field := 16#0#;
+      --  TIM7 timer reset
+      TIM7RST        : APB1RSTR_TIM7RST_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 reset
+      TIM14RST       : APB1RSTR_TIM14RST_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog reset
+      WWDGRST        : APB1RSTR_WWDGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI2 reset
+      SPI2RST        : APB1RSTR_SPI2RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 reset
+      USART2RST      : APB1RSTR_USART2RST_Field := 16#0#;
+      --  USART3 reset
+      USART3RST      : APB1RSTR_USART3RST_Field := 16#0#;
+      --  USART4 reset
+      USART4RST      : APB1RSTR_USART4RST_Field := 16#0#;
+      --  unspecified
+      Reserved_20_20 : Interfaces.STM32.Bit := 16#0#;
+      --  I2C1 reset
+      I2C1RST        : APB1RSTR_I2C1RST_Field := 16#0#;
+      --  I2C2 reset
+      I2C2RST        : APB1RSTR_I2C2RST_Field := 16#0#;
+      --  USB interface reset
+      USBRST         : APB1RSTR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_24 : Interfaces.STM32.Bit := 16#0#;
+      --  CAN interface reset
+      CANRST         : APB1RSTR_CANRST_Field := 16#0#;
+      --  unspecified
+      Reserved_26_26 : Interfaces.STM32.Bit := 16#0#;
+      --  Clock Recovery System interface reset
+      CRSRST         : APB1RSTR_CRSRST_Field := 16#0#;
+      --  Power interface reset
+      PWRRST         : APB1RSTR_PWRRST_Field := 16#0#;
+      --  DAC interface reset
+      DACRST         : APB1RSTR_DACRST_Field := 16#0#;
+      --  HDMI CEC reset
+      CECRST         : APB1RSTR_CECRST_Field := 16#0#;
+      --  unspecified
+      Reserved_31_31 : Interfaces.STM32.Bit := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1RSTR_Register use record
+      TIM2RST        at 0 range 0 .. 0;
+      TIM3RST        at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6RST        at 0 range 4 .. 4;
+      TIM7RST        at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14RST       at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGRST        at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2RST        at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2RST      at 0 range 17 .. 17;
+      USART3RST      at 0 range 18 .. 18;
+      USART4RST      at 0 range 19 .. 19;
+      Reserved_20_20 at 0 range 20 .. 20;
+      I2C1RST        at 0 range 21 .. 21;
+      I2C2RST        at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_24 at 0 range 24 .. 24;
+      CANRST         at 0 range 25 .. 25;
+      Reserved_26_26 at 0 range 26 .. 26;
+      CRSRST         at 0 range 27 .. 27;
+      PWRRST         at 0 range 28 .. 28;
+      DACRST         at 0 range 29 .. 29;
+      CECRST         at 0 range 30 .. 30;
+      Reserved_31_31 at 0 range 31 .. 31;
+   end record;
+
+   subtype AHBENR_DMA1EN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_SRAMEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_FLITFEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_CRCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPAEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPBEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPDEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPFEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_TSCEN_Field is Interfaces.STM32.Bit;
+
+   --  AHB Peripheral Clock enable register (RCC_AHBENR)
+   type AHBENR_Register is record
+      --  DMA1 clock enable
+      DMA1EN         : AHBENR_DMA1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_1_1   : Interfaces.STM32.Bit := 16#0#;
+      --  SRAM interface clock enable
+      SRAMEN         : AHBENR_SRAMEN_Field := 16#1#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  FLITF clock enable
+      FLITFEN        : AHBENR_FLITFEN_Field := 16#1#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  CRC clock enable
+      CRCEN          : AHBENR_CRCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_7_16  : Interfaces.STM32.UInt10 := 16#0#;
+      --  I/O port A clock enable
+      IOPAEN         : AHBENR_IOPAEN_Field := 16#0#;
+      --  I/O port B clock enable
+      IOPBEN         : AHBENR_IOPBEN_Field := 16#0#;
+      --  I/O port C clock enable
+      IOPCEN         : AHBENR_IOPCEN_Field := 16#0#;
+      --  I/O port D clock enable
+      IOPDEN         : AHBENR_IOPDEN_Field := 16#0#;
+      --  unspecified
+      Reserved_21_21 : Interfaces.STM32.Bit := 16#0#;
+      --  I/O port F clock enable
+      IOPFEN         : AHBENR_IOPFEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_23 : Interfaces.STM32.Bit := 16#0#;
+      --  Touch sensing controller clock enable
+      TSCEN          : AHBENR_TSCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBENR_Register use record
+      DMA1EN         at 0 range 0 .. 0;
+      Reserved_1_1   at 0 range 1 .. 1;
+      SRAMEN         at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      FLITFEN        at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CRCEN          at 0 range 6 .. 6;
+      Reserved_7_16  at 0 range 7 .. 16;
+      IOPAEN         at 0 range 17 .. 17;
+      IOPBEN         at 0 range 18 .. 18;
+      IOPCEN         at 0 range 19 .. 19;
+      IOPDEN         at 0 range 20 .. 20;
+      Reserved_21_21 at 0 range 21 .. 21;
+      IOPFEN         at 0 range 22 .. 22;
+      Reserved_23_23 at 0 range 23 .. 23;
+      TSCEN          at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   subtype APB2ENR_SYSCFGEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_ADCEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_SPI1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_USART1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM15EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM16EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM17EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_DBGMCUEN_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral clock enable register (RCC_APB2ENR)
+   type APB2ENR_Register is record
+      --  SYSCFG clock enable
+      SYSCFGEN       : APB2ENR_SYSCFGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_1_8   : Interfaces.STM32.Byte := 16#0#;
+      --  ADC 1 interface clock enable
+      ADCEN          : APB2ENR_ADCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 Timer clock enable
+      TIM1EN         : APB2ENR_TIM1EN_Field := 16#0#;
+      --  SPI 1 clock enable
+      SPI1EN         : APB2ENR_SPI1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 clock enable
+      USART1EN       : APB2ENR_USART1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer clock enable
+      TIM15EN        : APB2ENR_TIM15EN_Field := 16#0#;
+      --  TIM16 timer clock enable
+      TIM16EN        : APB2ENR_TIM16EN_Field := 16#0#;
+      --  TIM17 timer clock enable
+      TIM17EN        : APB2ENR_TIM17EN_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  MCU debug module clock enable
+      DBGMCUEN       : APB2ENR_DBGMCUEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2ENR_Register use record
+      SYSCFGEN       at 0 range 0 .. 0;
+      Reserved_1_8   at 0 range 1 .. 8;
+      ADCEN          at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1EN         at 0 range 11 .. 11;
+      SPI1EN         at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1EN       at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15EN        at 0 range 16 .. 16;
+      TIM16EN        at 0 range 17 .. 17;
+      TIM17EN        at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCUEN       at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1ENR_TIM2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM6EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM7EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM14EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_WWDGEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_SPI2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART4EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C1EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CANEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CRSEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_PWREN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_DACEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CECEN_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral clock enable register (RCC_APB1ENR)
+   type APB1ENR_Register is record
+      --  Timer 2 clock enable
+      TIM2EN         : APB1ENR_TIM2EN_Field := 16#0#;
+      --  Timer 3 clock enable
+      TIM3EN         : APB1ENR_TIM3EN_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 clock enable
+      TIM6EN         : APB1ENR_TIM6EN_Field := 16#0#;
+      --  TIM7 timer clock enable
+      TIM7EN         : APB1ENR_TIM7EN_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 clock enable
+      TIM14EN        : APB1ENR_TIM14EN_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog clock enable
+      WWDGEN         : APB1ENR_WWDGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI 2 clock enable
+      SPI2EN         : APB1ENR_SPI2EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 clock enable
+      USART2EN       : APB1ENR_USART2EN_Field := 16#0#;
+      --  USART3 clock enable
+      USART3EN       : APB1ENR_USART3EN_Field := 16#0#;
+      --  USART4 clock enable
+      USART4EN       : APB1ENR_USART4EN_Field := 16#0#;
+      --  unspecified
+      Reserved_20_20 : Interfaces.STM32.Bit := 16#0#;
+      --  I2C 1 clock enable
+      I2C1EN         : APB1ENR_I2C1EN_Field := 16#0#;
+      --  I2C 2 clock enable
+      I2C2EN         : APB1ENR_I2C2EN_Field := 16#0#;
+      --  USB interface clock enable
+      USBRST         : APB1ENR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_24 : Interfaces.STM32.Bit := 16#0#;
+      --  CAN interface clock enable
+      CANEN          : APB1ENR_CANEN_Field := 16#0#;
+      --  unspecified
+      Reserved_26_26 : Interfaces.STM32.Bit := 16#0#;
+      --  Clock Recovery System interface clock enable
+      CRSEN          : APB1ENR_CRSEN_Field := 16#0#;
+      --  Power interface clock enable
+      PWREN          : APB1ENR_PWREN_Field := 16#0#;
+      --  DAC interface clock enable
+      DACEN          : APB1ENR_DACEN_Field := 16#0#;
+      --  HDMI CEC interface clock enable
+      CECEN          : APB1ENR_CECEN_Field := 16#0#;
+      --  unspecified
+      Reserved_31_31 : Interfaces.STM32.Bit := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1ENR_Register use record
+      TIM2EN         at 0 range 0 .. 0;
+      TIM3EN         at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6EN         at 0 range 4 .. 4;
+      TIM7EN         at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14EN        at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGEN         at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2EN         at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2EN       at 0 range 17 .. 17;
+      USART3EN       at 0 range 18 .. 18;
+      USART4EN       at 0 range 19 .. 19;
+      Reserved_20_20 at 0 range 20 .. 20;
+      I2C1EN         at 0 range 21 .. 21;
+      I2C2EN         at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_24 at 0 range 24 .. 24;
+      CANEN          at 0 range 25 .. 25;
+      Reserved_26_26 at 0 range 26 .. 26;
+      CRSEN          at 0 range 27 .. 27;
+      PWREN          at 0 range 28 .. 28;
+      DACEN          at 0 range 29 .. 29;
+      CECEN          at 0 range 30 .. 30;
+      Reserved_31_31 at 0 range 31 .. 31;
+   end record;
+
+   subtype BDCR_LSEON_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSERDY_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEBYP_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEDRV_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCSEL_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCEN_Field is Interfaces.STM32.Bit;
+   subtype BDCR_BDRST_Field is Interfaces.STM32.Bit;
+
+   --  Backup domain control register (RCC_BDCR)
+   type BDCR_Register is record
+      --  External Low Speed oscillator enable
+      LSEON          : BDCR_LSEON_Field := 16#0#;
+      --  Read-only. External Low Speed oscillator ready
+      LSERDY         : BDCR_LSERDY_Field := 16#0#;
+      --  External Low Speed oscillator bypass
+      LSEBYP         : BDCR_LSEBYP_Field := 16#0#;
+      --  LSE oscillator drive capability
+      LSEDRV         : BDCR_LSEDRV_Field := 16#0#;
+      --  unspecified
+      Reserved_5_7   : Interfaces.STM32.UInt3 := 16#0#;
+      --  RTC clock source selection
+      RTCSEL         : BDCR_RTCSEL_Field := 16#0#;
+      --  unspecified
+      Reserved_10_14 : Interfaces.STM32.UInt5 := 16#0#;
+      --  RTC clock enable
+      RTCEN          : BDCR_RTCEN_Field := 16#0#;
+      --  Backup domain software reset
+      BDRST          : BDCR_BDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_17_31 : Interfaces.STM32.UInt15 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for BDCR_Register use record
+      LSEON          at 0 range 0 .. 0;
+      LSERDY         at 0 range 1 .. 1;
+      LSEBYP         at 0 range 2 .. 2;
+      LSEDRV         at 0 range 3 .. 4;
+      Reserved_5_7   at 0 range 5 .. 7;
+      RTCSEL         at 0 range 8 .. 9;
+      Reserved_10_14 at 0 range 10 .. 14;
+      RTCEN          at 0 range 15 .. 15;
+      BDRST          at 0 range 16 .. 16;
+      Reserved_17_31 at 0 range 17 .. 31;
+   end record;
+
+   subtype CSR_LSION_Field is Interfaces.STM32.Bit;
+   subtype CSR_LSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CSR_RMVF_Field is Interfaces.STM32.Bit;
+   subtype CSR_OBLRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PINRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PORRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_SFTRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_IWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_WWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_LPWRRSTF_Field is Interfaces.STM32.Bit;
+
+   --  Control/status register (RCC_CSR)
+   type CSR_Register is record
+      --  Internal low speed oscillator enable
+      LSION         : CSR_LSION_Field := 16#0#;
+      --  Read-only. Internal low speed oscillator ready
+      LSIRDY        : CSR_LSIRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_2_23 : Interfaces.STM32.UInt22 := 16#0#;
+      --  Remove reset flag
+      RMVF          : CSR_RMVF_Field := 16#0#;
+      --  Option byte loader reset flag
+      OBLRSTF       : CSR_OBLRSTF_Field := 16#0#;
+      --  PIN reset flag
+      PINRSTF       : CSR_PINRSTF_Field := 16#1#;
+      --  POR/PDR reset flag
+      PORRSTF       : CSR_PORRSTF_Field := 16#1#;
+      --  Software reset flag
+      SFTRSTF       : CSR_SFTRSTF_Field := 16#0#;
+      --  Independent watchdog reset flag
+      IWDGRSTF      : CSR_IWDGRSTF_Field := 16#0#;
+      --  Window watchdog reset flag
+      WWDGRSTF      : CSR_WWDGRSTF_Field := 16#0#;
+      --  Low-power reset flag
+      LPWRRSTF      : CSR_LPWRRSTF_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CSR_Register use record
+      LSION         at 0 range 0 .. 0;
+      LSIRDY        at 0 range 1 .. 1;
+      Reserved_2_23 at 0 range 2 .. 23;
+      RMVF          at 0 range 24 .. 24;
+      OBLRSTF       at 0 range 25 .. 25;
+      PINRSTF       at 0 range 26 .. 26;
+      PORRSTF       at 0 range 27 .. 27;
+      SFTRSTF       at 0 range 28 .. 28;
+      IWDGRSTF      at 0 range 29 .. 29;
+      WWDGRSTF      at 0 range 30 .. 30;
+      LPWRRSTF      at 0 range 31 .. 31;
+   end record;
+
+   subtype AHBRSTR_IOPARST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPBRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPCRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPDRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPFRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_TSCRST_Field is Interfaces.STM32.Bit;
+
+   --  AHB peripheral reset register
+   type AHBRSTR_Register is record
+      --  unspecified
+      Reserved_0_16  : Interfaces.STM32.UInt17 := 16#0#;
+      --  I/O port A reset
+      IOPARST        : AHBRSTR_IOPARST_Field := 16#0#;
+      --  I/O port B reset
+      IOPBRST        : AHBRSTR_IOPBRST_Field := 16#0#;
+      --  I/O port C reset
+      IOPCRST        : AHBRSTR_IOPCRST_Field := 16#0#;
+      --  I/O port D reset
+      IOPDRST        : AHBRSTR_IOPDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_21_21 : Interfaces.STM32.Bit := 16#0#;
+      --  I/O port F reset
+      IOPFRST        : AHBRSTR_IOPFRST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_23 : Interfaces.STM32.Bit := 16#0#;
+      --  Touch sensing controller reset
+      TSCRST         : AHBRSTR_TSCRST_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBRSTR_Register use record
+      Reserved_0_16  at 0 range 0 .. 16;
+      IOPARST        at 0 range 17 .. 17;
+      IOPBRST        at 0 range 18 .. 18;
+      IOPCRST        at 0 range 19 .. 19;
+      IOPDRST        at 0 range 20 .. 20;
+      Reserved_21_21 at 0 range 21 .. 21;
+      IOPFRST        at 0 range 22 .. 22;
+      Reserved_23_23 at 0 range 23 .. 23;
+      TSCRST         at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   subtype CFGR2_PREDIV_Field is Interfaces.STM32.UInt4;
+
+   --  Clock configuration register 2
+   type CFGR2_Register is record
+      --  PREDIV division factor
+      PREDIV        : CFGR2_PREDIV_Field := 16#0#;
+      --  unspecified
+      Reserved_4_31 : Interfaces.STM32.UInt28 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR2_Register use record
+      PREDIV        at 0 range 0 .. 3;
+      Reserved_4_31 at 0 range 4 .. 31;
+   end record;
+
+   subtype CFGR3_USART1SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR3_I2C1SW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_CECSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USBSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_ADCSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USART2SW_Field is Interfaces.STM32.UInt2;
+
+   --  Clock configuration register 3
+   type CFGR3_Register is record
+      --  USART1 clock source selection
+      USART1SW       : CFGR3_USART1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  I2C1 clock source selection
+      I2C1SW         : CFGR3_I2C1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  HDMI CEC clock source selection
+      CECSW          : CFGR3_CECSW_Field := 16#0#;
+      --  USB clock source selection
+      USBSW          : CFGR3_USBSW_Field := 16#0#;
+      --  ADC clock source selection
+      ADCSW          : CFGR3_ADCSW_Field := 16#0#;
+      --  unspecified
+      Reserved_9_15  : Interfaces.STM32.UInt7 := 16#0#;
+      --  USART2 clock source selection
+      USART2SW       : CFGR3_USART2SW_Field := 16#0#;
+      --  unspecified
+      Reserved_18_31 : Interfaces.STM32.UInt14 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR3_Register use record
+      USART1SW       at 0 range 0 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      I2C1SW         at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CECSW          at 0 range 6 .. 6;
+      USBSW          at 0 range 7 .. 7;
+      ADCSW          at 0 range 8 .. 8;
+      Reserved_9_15  at 0 range 9 .. 15;
+      USART2SW       at 0 range 16 .. 17;
+      Reserved_18_31 at 0 range 18 .. 31;
+   end record;
+
+   subtype CR2_HSI14ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14DIS_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14TRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR2_HSI14CAL_Field is Interfaces.STM32.Byte;
+   subtype CR2_HSI48ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48CAL_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register 2
+   type CR2_Register is record
+      --  HSI14 clock enable
+      HSI14ON        : CR2_HSI14ON_Field := 16#0#;
+      --  Read-only. HR14 clock ready flag
+      HSI14RDY       : CR2_HSI14RDY_Field := 16#0#;
+      --  HSI14 clock request from ADC disable
+      HSI14DIS       : CR2_HSI14DIS_Field := 16#0#;
+      --  HSI14 clock trimming
+      HSI14TRIM      : CR2_HSI14TRIM_Field := 16#10#;
+      --  Read-only. HSI14 clock calibration
+      HSI14CAL       : CR2_HSI14CAL_Field := 16#0#;
+      --  HSI48 clock enable
+      HSI48ON        : CR2_HSI48ON_Field := 16#0#;
+      --  Read-only. HSI48 clock ready flag
+      HSI48RDY       : CR2_HSI48RDY_Field := 16#0#;
+      --  unspecified
+      Reserved_18_23 : Interfaces.STM32.UInt6 := 16#0#;
+      --  Read-only. HSI48 factory clock calibration
+      HSI48CAL       : CR2_HSI48CAL_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR2_Register use record
+      HSI14ON        at 0 range 0 .. 0;
+      HSI14RDY       at 0 range 1 .. 1;
+      HSI14DIS       at 0 range 2 .. 2;
+      HSI14TRIM      at 0 range 3 .. 7;
+      HSI14CAL       at 0 range 8 .. 15;
+      HSI48ON        at 0 range 16 .. 16;
+      HSI48RDY       at 0 range 17 .. 17;
+      Reserved_18_23 at 0 range 18 .. 23;
+      HSI48CAL       at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Reset and clock control
+   type RCC_Peripheral is record
+      --  Clock control register
+      CR       : aliased CR_Register;
+      --  Clock configuration register (RCC_CFGR)
+      CFGR     : aliased CFGR_Register;
+      --  Clock interrupt register (RCC_CIR)
+      CIR      : aliased CIR_Register;
+      --  APB2 peripheral reset register (RCC_APB2RSTR)
+      APB2RSTR : aliased APB2RSTR_Register;
+      --  APB1 peripheral reset register (RCC_APB1RSTR)
+      APB1RSTR : aliased APB1RSTR_Register;
+      --  AHB Peripheral Clock enable register (RCC_AHBENR)
+      AHBENR   : aliased AHBENR_Register;
+      --  APB2 peripheral clock enable register (RCC_APB2ENR)
+      APB2ENR  : aliased APB2ENR_Register;
+      --  APB1 peripheral clock enable register (RCC_APB1ENR)
+      APB1ENR  : aliased APB1ENR_Register;
+      --  Backup domain control register (RCC_BDCR)
+      BDCR     : aliased BDCR_Register;
+      --  Control/status register (RCC_CSR)
+      CSR      : aliased CSR_Register;
+      --  AHB peripheral reset register
+      AHBRSTR  : aliased AHBRSTR_Register;
+      --  Clock configuration register 2
+      CFGR2    : aliased CFGR2_Register;
+      --  Clock configuration register 3
+      CFGR3    : aliased CFGR3_Register;
+      --  Clock control register 2
+      CR2      : aliased CR2_Register;
+   end record
+     with Volatile;
+
+   for RCC_Peripheral use record
+      CR       at 16#0# range 0 .. 31;
+      CFGR     at 16#4# range 0 .. 31;
+      CIR      at 16#8# range 0 .. 31;
+      APB2RSTR at 16#C# range 0 .. 31;
+      APB1RSTR at 16#10# range 0 .. 31;
+      AHBENR   at 16#14# range 0 .. 31;
+      APB2ENR  at 16#18# range 0 .. 31;
+      APB1ENR  at 16#1C# range 0 .. 31;
+      BDCR     at 16#20# range 0 .. 31;
+      CSR      at 16#24# range 0 .. 31;
+      AHBRSTR  at 16#28# range 0 .. 31;
+      CFGR2    at 16#2C# range 0 .. 31;
+      CFGR3    at 16#30# range 0 .. 31;
+      CR2      at 16#34# range 0 .. 31;
+   end record;
+
+   --  Reset and clock control
+   RCC_Periph : aliased RCC_Peripheral
+     with Import, Address => RCC_Base;
+
+end Interfaces.STM32.RCC;

--- a/arm/stm32/stm32f0xx/stm32f0x2/svd/i-stm32.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x2/svd/i-stm32.ads
@@ -1,0 +1,132 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x2.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+--  STM32F0x2
+package Interfaces.STM32 is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Base type --
+   ---------------
+
+   type UInt32 is new Interfaces.Unsigned_32;
+   type UInt16 is new Interfaces.Unsigned_16;
+   type Byte is new Interfaces.Unsigned_8;
+   type Bit is mod 2**1
+     with Size => 1;
+   type UInt2 is mod 2**2
+     with Size => 2;
+   type UInt3 is mod 2**3
+     with Size => 3;
+   type UInt4 is mod 2**4
+     with Size => 4;
+   type UInt5 is mod 2**5
+     with Size => 5;
+   type UInt6 is mod 2**6
+     with Size => 6;
+   type UInt7 is mod 2**7
+     with Size => 7;
+   type UInt9 is mod 2**9
+     with Size => 9;
+   type UInt10 is mod 2**10
+     with Size => 10;
+   type UInt11 is mod 2**11
+     with Size => 11;
+   type UInt12 is mod 2**12
+     with Size => 12;
+   type UInt13 is mod 2**13
+     with Size => 13;
+   type UInt14 is mod 2**14
+     with Size => 14;
+   type UInt15 is mod 2**15
+     with Size => 15;
+   type UInt17 is mod 2**17
+     with Size => 17;
+   type UInt18 is mod 2**18
+     with Size => 18;
+   type UInt19 is mod 2**19
+     with Size => 19;
+   type UInt20 is mod 2**20
+     with Size => 20;
+   type UInt21 is mod 2**21
+     with Size => 21;
+   type UInt22 is mod 2**22
+     with Size => 22;
+   type UInt23 is mod 2**23
+     with Size => 23;
+   type UInt24 is mod 2**24
+     with Size => 24;
+   type UInt25 is mod 2**25
+     with Size => 25;
+   type UInt26 is mod 2**26
+     with Size => 26;
+   type UInt27 is mod 2**27
+     with Size => 27;
+   type UInt28 is mod 2**28
+     with Size => 28;
+   type UInt29 is mod 2**29
+     with Size => 29;
+   type UInt30 is mod 2**30
+     with Size => 30;
+   type UInt31 is mod 2**31
+     with Size => 31;
+
+   --------------------
+   -- Base addresses --
+   --------------------
+
+   CRC_Base : constant System.Address := System'To_Address (16#40023000#);
+   GPIOF_Base : constant System.Address := System'To_Address (16#48001400#);
+   GPIOD_Base : constant System.Address := System'To_Address (16#48000C00#);
+   GPIOC_Base : constant System.Address := System'To_Address (16#48000800#);
+   GPIOB_Base : constant System.Address := System'To_Address (16#48000400#);
+   GPIOE_Base : constant System.Address := System'To_Address (16#48001000#);
+   GPIOA_Base : constant System.Address := System'To_Address (16#48000000#);
+   SPI1_Base : constant System.Address := System'To_Address (16#40013000#);
+   SPI2_Base : constant System.Address := System'To_Address (16#40003800#);
+   DAC_Base : constant System.Address := System'To_Address (16#40007400#);
+   PWR_Base : constant System.Address := System'To_Address (16#40007000#);
+   I2C1_Base : constant System.Address := System'To_Address (16#40005400#);
+   I2C2_Base : constant System.Address := System'To_Address (16#40005800#);
+   IWDG_Base : constant System.Address := System'To_Address (16#40003000#);
+   WWDG_Base : constant System.Address := System'To_Address (16#40002C00#);
+   TIM1_Base : constant System.Address := System'To_Address (16#40012C00#);
+   TIM2_Base : constant System.Address := System'To_Address (16#40000000#);
+   TIM3_Base : constant System.Address := System'To_Address (16#40000400#);
+   TIM14_Base : constant System.Address := System'To_Address (16#40002000#);
+   TIM6_Base : constant System.Address := System'To_Address (16#40001000#);
+   TIM7_Base : constant System.Address := System'To_Address (16#40001400#);
+   EXTI_Base : constant System.Address := System'To_Address (16#40010400#);
+   NVIC_Base : constant System.Address := System'To_Address (16#E000E100#);
+   DMA1_Base : constant System.Address := System'To_Address (16#40020000#);
+   RCC_Base : constant System.Address := System'To_Address (16#40021000#);
+   SYSCFG_COMP_Base : constant System.Address := System'To_Address (16#40010000#);
+   ADC_Base : constant System.Address := System'To_Address (16#40012400#);
+   USART1_Base : constant System.Address := System'To_Address (16#40013800#);
+   USART2_Base : constant System.Address := System'To_Address (16#40004400#);
+   USART3_Base : constant System.Address := System'To_Address (16#40004800#);
+   USART4_Base : constant System.Address := System'To_Address (16#40004C00#);
+   RTC_Base : constant System.Address := System'To_Address (16#40002800#);
+   TIM15_Base : constant System.Address := System'To_Address (16#40014000#);
+   TIM16_Base : constant System.Address := System'To_Address (16#40014400#);
+   TIM17_Base : constant System.Address := System'To_Address (16#40014800#);
+   TSC_Base : constant System.Address := System'To_Address (16#40024000#);
+   CEC_Base : constant System.Address := System'To_Address (16#40007800#);
+   Flash_Base : constant System.Address := System'To_Address (16#40022000#);
+   DBGMCU_Base : constant System.Address := System'To_Address (16#40015800#);
+   USB_Base : constant System.Address := System'To_Address (16#40005C00#);
+   CRS_Base : constant System.Address := System'To_Address (16#40006C00#);
+   CAN_Base : constant System.Address := System'To_Address (16#40006400#);
+   SCB_Base : constant System.Address := System'To_Address (16#E000ED00#);
+   STK_Base : constant System.Address := System'To_Address (16#E000E010#);
+
+end Interfaces.STM32;

--- a/arm/stm32/stm32f0xx/stm32f0x8/svd/a-intnam.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x8/svd/a-intnam.ads
@@ -1,0 +1,117 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x8.svd
+
+--  This is a version for the STM32F0x8 MCU
+package Ada.Interrupts.Names is
+
+   --  All identifiers in this unit are implementation defined
+
+   pragma Implementation_Defined;
+
+   ----------------
+   -- Interrupts --
+   ----------------
+
+   --  System tick
+   Sys_Tick_Interrupt                     : constant Interrupt_ID := -1;
+
+   --  Window Watchdog interrupt
+   WWDG_Interrupt                         : constant Interrupt_ID := 0;
+
+   --  PVD and VDDIO2 supply comparator interrupt
+   PVD_Interrupt                          : constant Interrupt_ID := 1;
+
+   --  RTC interrupts
+   RTC_Interrupt                          : constant Interrupt_ID := 2;
+
+   --  Flash global interrupt
+   FLASH_Interrupt                        : constant Interrupt_ID := 3;
+
+   --  RCC and CRS global interrupts
+   RCC_CRS_Interrupt                      : constant Interrupt_ID := 4;
+
+   --  EXTI Line[1:0] interrupts
+   EXTI0_1_Interrupt                      : constant Interrupt_ID := 5;
+
+   --  EXTI Line[3:2] interrupts
+   EXTI2_3_Interrupt                      : constant Interrupt_ID := 6;
+
+   --  EXTI Line15 and EXTI4 interrupts
+   EXTI4_15_Interrupt                     : constant Interrupt_ID := 7;
+
+   --  Touch sensing interrupt
+   TSC_Interrupt                          : constant Interrupt_ID := 8;
+
+   --  DMA1 channel 1 interrupt
+   DMA1_CH1_Interrupt                     : constant Interrupt_ID := 9;
+
+   --  DMA1 channel 2 and 3 and DMA2 channel 1 and 2 interrupt
+   DMA1_CH2_3_DMA2_CH1_2_Interrupt        : constant Interrupt_ID := 10;
+
+   --  DMA1 channel 4, 5, 6 and 7 and DMA2 channel 3, 4 and 5 interrupts
+   DMA1_CH4_5_6_7_DMA2_CH3_4_5_Interrupt  : constant Interrupt_ID := 11;
+
+   --  ADC and comparator interrupts
+   ADC_COMP_Interrupt                     : constant Interrupt_ID := 12;
+
+   --  TIM1 break, update, trigger and commutation interrupt
+   TIM1_BRK_UP_TRG_COM_Interrupt          : constant Interrupt_ID := 13;
+
+   --  TIM1 Capture Compare interrupt
+   TIM1_CC_Interrupt                      : constant Interrupt_ID := 14;
+
+   --  TIM2 global interrupt
+   TIM2_Interrupt                         : constant Interrupt_ID := 15;
+
+   --  TIM3 global interrupt
+   TIM3_Interrupt                         : constant Interrupt_ID := 16;
+
+   --  TIM6 global interrupt and DAC underrun interrupt
+   TIM6_DAC_Interrupt                     : constant Interrupt_ID := 17;
+
+   --  TIM7 global interrupt
+   TIM7_Interrupt                         : constant Interrupt_ID := 18;
+
+   --  TIM14 global interrupt
+   TIM14_Interrupt                        : constant Interrupt_ID := 19;
+
+   --  TIM15 global interrupt
+   TIM15_Interrupt                        : constant Interrupt_ID := 20;
+
+   --  TIM16 global interrupt
+   TIM16_Interrupt                        : constant Interrupt_ID := 21;
+
+   --  TIM17 global interrupt
+   TIM17_Interrupt                        : constant Interrupt_ID := 22;
+
+   --  I2C1 global interrupt
+   I2C1_Interrupt                         : constant Interrupt_ID := 23;
+
+   --  I2C2 global interrupt
+   I2C2_Interrupt                         : constant Interrupt_ID := 24;
+
+   --  SPI1_global_interrupt
+   SPI1_Interrupt                         : constant Interrupt_ID := 25;
+
+   --  SPI2 global interrupt
+   SPI2_Interrupt                         : constant Interrupt_ID := 26;
+
+   --  USART1 global interrupt
+   USART1_Interrupt                       : constant Interrupt_ID := 27;
+
+   --  USART2 global interrupt
+   USART2_Interrupt                       : constant Interrupt_ID := 28;
+
+   --  USART3, USART4, USART5, USART6, USART7, USART8 global interrupt
+   USART3_4_5_6_7_8_Interrupt             : constant Interrupt_ID := 29;
+
+   --  CEC and CAN global interrupt
+   CEC_CAN_Interrupt                      : constant Interrupt_ID := 30;
+
+   --  USB global interrupt
+   USB_Interrupt                          : constant Interrupt_ID := 31;
+
+end Ada.Interrupts.Names;

--- a/arm/stm32/stm32f0xx/stm32f0x8/svd/i-stm32-flash.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x8/svd/i-stm32-flash.ads
@@ -1,0 +1,293 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x8.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.Flash is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype ACR_LATENCY_Field is Interfaces.STM32.UInt3;
+   subtype ACR_PRFTBE_Field is Interfaces.STM32.Bit;
+   subtype ACR_PRFTBS_Field is Interfaces.STM32.Bit;
+
+   --  Flash access control register
+   type ACR_Register is record
+      --  LATENCY
+      LATENCY       : ACR_LATENCY_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  PRFTBE
+      PRFTBE        : ACR_PRFTBE_Field := 16#1#;
+      --  Read-only. PRFTBS
+      PRFTBS        : ACR_PRFTBS_Field := 16#1#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for ACR_Register use record
+      LATENCY       at 0 range 0 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      PRFTBE        at 0 range 4 .. 4;
+      PRFTBS        at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype SR_BSY_Field is Interfaces.STM32.Bit;
+   subtype SR_PGERR_Field is Interfaces.STM32.Bit;
+   subtype SR_WRPRT_Field is Interfaces.STM32.Bit;
+   subtype SR_EOP_Field is Interfaces.STM32.Bit;
+
+   --  Flash status register
+   type SR_Register is record
+      --  Read-only. Busy
+      BSY           : SR_BSY_Field := 16#0#;
+      --  unspecified
+      Reserved_1_1  : Interfaces.STM32.Bit := 16#0#;
+      --  Programming error
+      PGERR         : SR_PGERR_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3  : Interfaces.STM32.Bit := 16#0#;
+      --  Write protection error
+      WRPRT         : SR_WRPRT_Field := 16#0#;
+      --  End of operation
+      EOP           : SR_EOP_Field := 16#0#;
+      --  unspecified
+      Reserved_6_31 : Interfaces.STM32.UInt26 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for SR_Register use record
+      BSY           at 0 range 0 .. 0;
+      Reserved_1_1  at 0 range 1 .. 1;
+      PGERR         at 0 range 2 .. 2;
+      Reserved_3_3  at 0 range 3 .. 3;
+      WRPRT         at 0 range 4 .. 4;
+      EOP           at 0 range 5 .. 5;
+      Reserved_6_31 at 0 range 6 .. 31;
+   end record;
+
+   subtype CR_PG_Field is Interfaces.STM32.Bit;
+   subtype CR_PER_Field is Interfaces.STM32.Bit;
+   subtype CR_MER_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTPG_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTER_Field is Interfaces.STM32.Bit;
+   subtype CR_STRT_Field is Interfaces.STM32.Bit;
+   subtype CR_LOCK_Field is Interfaces.STM32.Bit;
+   subtype CR_OPTWRE_Field is Interfaces.STM32.Bit;
+   subtype CR_ERRIE_Field is Interfaces.STM32.Bit;
+   subtype CR_EOPIE_Field is Interfaces.STM32.Bit;
+   subtype CR_FORCE_OPTLOAD_Field is Interfaces.STM32.Bit;
+
+   --  Flash control register
+   type CR_Register is record
+      --  Programming
+      PG             : CR_PG_Field := 16#0#;
+      --  Page erase
+      PER            : CR_PER_Field := 16#0#;
+      --  Mass erase
+      MER            : CR_MER_Field := 16#0#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  Option byte programming
+      OPTPG          : CR_OPTPG_Field := 16#0#;
+      --  Option byte erase
+      OPTER          : CR_OPTER_Field := 16#0#;
+      --  Start
+      STRT           : CR_STRT_Field := 16#0#;
+      --  Lock
+      LOCK           : CR_LOCK_Field := 16#1#;
+      --  unspecified
+      Reserved_8_8   : Interfaces.STM32.Bit := 16#0#;
+      --  Option bytes write enable
+      OPTWRE         : CR_OPTWRE_Field := 16#0#;
+      --  Error interrupt enable
+      ERRIE          : CR_ERRIE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_11 : Interfaces.STM32.Bit := 16#0#;
+      --  End of operation interrupt enable
+      EOPIE          : CR_EOPIE_Field := 16#0#;
+      --  Force option byte loading
+      FORCE_OPTLOAD  : CR_FORCE_OPTLOAD_Field := 16#0#;
+      --  unspecified
+      Reserved_14_31 : Interfaces.STM32.UInt18 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      PG             at 0 range 0 .. 0;
+      PER            at 0 range 1 .. 1;
+      MER            at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      OPTPG          at 0 range 4 .. 4;
+      OPTER          at 0 range 5 .. 5;
+      STRT           at 0 range 6 .. 6;
+      LOCK           at 0 range 7 .. 7;
+      Reserved_8_8   at 0 range 8 .. 8;
+      OPTWRE         at 0 range 9 .. 9;
+      ERRIE          at 0 range 10 .. 10;
+      Reserved_11_11 at 0 range 11 .. 11;
+      EOPIE          at 0 range 12 .. 12;
+      FORCE_OPTLOAD  at 0 range 13 .. 13;
+      Reserved_14_31 at 0 range 14 .. 31;
+   end record;
+
+   subtype OBR_OPTERR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RDPRT_Field is Interfaces.STM32.UInt2;
+   subtype OBR_WDG_SW_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STOP_Field is Interfaces.STM32.Bit;
+   subtype OBR_nRST_STDBY_Field is Interfaces.STM32.Bit;
+   --  OBR_nBOOT array element
+   subtype OBR_nBOOT_Element is Interfaces.STM32.Bit;
+
+   --  OBR_nBOOT array
+   type OBR_nBOOT_Field_Array is array (0 .. 1) of OBR_nBOOT_Element
+     with Component_Size => 1, Size => 2;
+
+   --  Type definition for OBR_nBOOT
+   type OBR_nBOOT_Field
+     (As_Array : Boolean := False)
+   is record
+      case As_Array is
+         when False =>
+            --  nBOOT as a value
+            Val : Interfaces.STM32.UInt2;
+         when True =>
+            --  nBOOT as an array
+            Arr : OBR_nBOOT_Field_Array;
+      end case;
+   end record
+     with Unchecked_Union, Size => 2;
+
+   for OBR_nBOOT_Field use record
+      Val at 0 range 0 .. 1;
+      Arr at 0 range 0 .. 1;
+   end record;
+
+   subtype OBR_VDDA_MONITOR_Field is Interfaces.STM32.Bit;
+   subtype OBR_RAM_PARITY_CHECK_Field is Interfaces.STM32.Bit;
+   subtype OBR_BOOT_SEL_Field is Interfaces.STM32.Bit;
+   --  OBR_Data array element
+   subtype OBR_Data_Element is Interfaces.STM32.Byte;
+
+   --  OBR_Data array
+   type OBR_Data_Field_Array is array (0 .. 1) of OBR_Data_Element
+     with Component_Size => 8, Size => 16;
+
+   --  Type definition for OBR_Data
+   type OBR_Data_Field
+     (As_Array : Boolean := False)
+   is record
+      case As_Array is
+         when False =>
+            --  Data as a value
+            Val : Interfaces.STM32.UInt16;
+         when True =>
+            --  Data as an array
+            Arr : OBR_Data_Field_Array;
+      end case;
+   end record
+     with Unchecked_Union, Size => 16;
+
+   for OBR_Data_Field use record
+      Val at 0 range 0 .. 15;
+      Arr at 0 range 0 .. 15;
+   end record;
+
+   --  Option byte register
+   type OBR_Register is record
+      --  Read-only. Option byte error
+      OPTERR           : OBR_OPTERR_Field;
+      --  Read-only. Read protection level status
+      RDPRT            : OBR_RDPRT_Field;
+      --  unspecified
+      Reserved_3_7     : Interfaces.STM32.UInt5;
+      --  Read-only. WDG_SW
+      WDG_SW           : OBR_WDG_SW_Field;
+      --  Read-only. nRST_STOP
+      nRST_STOP        : OBR_nRST_STOP_Field;
+      --  Read-only. nRST_STDBY
+      nRST_STDBY       : OBR_nRST_STDBY_Field;
+      --  Read-only. nBOOT0
+      nBOOT            : OBR_nBOOT_Field;
+      --  Read-only. VDDA_MONITOR
+      VDDA_MONITOR     : OBR_VDDA_MONITOR_Field;
+      --  Read-only. RAM_PARITY_CHECK
+      RAM_PARITY_CHECK : OBR_RAM_PARITY_CHECK_Field;
+      --  Read-only. BOOT_SEL
+      BOOT_SEL         : OBR_BOOT_SEL_Field;
+      --  Read-only. Data0
+      Data             : OBR_Data_Field;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for OBR_Register use record
+      OPTERR           at 0 range 0 .. 0;
+      RDPRT            at 0 range 1 .. 2;
+      Reserved_3_7     at 0 range 3 .. 7;
+      WDG_SW           at 0 range 8 .. 8;
+      nRST_STOP        at 0 range 9 .. 9;
+      nRST_STDBY       at 0 range 10 .. 10;
+      nBOOT            at 0 range 11 .. 12;
+      VDDA_MONITOR     at 0 range 13 .. 13;
+      RAM_PARITY_CHECK at 0 range 14 .. 14;
+      BOOT_SEL         at 0 range 15 .. 15;
+      Data             at 0 range 16 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Flash
+   type Flash_Peripheral is record
+      --  Flash access control register
+      ACR     : aliased ACR_Register;
+      --  Flash key register
+      KEYR    : aliased Interfaces.STM32.UInt32;
+      --  Flash option key register
+      OPTKEYR : aliased Interfaces.STM32.UInt32;
+      --  Flash status register
+      SR      : aliased SR_Register;
+      --  Flash control register
+      CR      : aliased CR_Register;
+      --  Flash address register
+      AR      : aliased Interfaces.STM32.UInt32;
+      --  Option byte register
+      OBR     : aliased OBR_Register;
+      --  Write protection register
+      WRPR    : aliased Interfaces.STM32.UInt32;
+   end record
+     with Volatile;
+
+   for Flash_Peripheral use record
+      ACR     at 16#0# range 0 .. 31;
+      KEYR    at 16#4# range 0 .. 31;
+      OPTKEYR at 16#8# range 0 .. 31;
+      SR      at 16#C# range 0 .. 31;
+      CR      at 16#10# range 0 .. 31;
+      AR      at 16#14# range 0 .. 31;
+      OBR     at 16#1C# range 0 .. 31;
+      WRPR    at 16#20# range 0 .. 31;
+   end record;
+
+   --  Flash
+   Flash_Periph : aliased Flash_Peripheral
+     with Import, Address => Flash_Base;
+
+end Interfaces.STM32.Flash;

--- a/arm/stm32/stm32f0xx/stm32f0x8/svd/i-stm32-rcc.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x8/svd/i-stm32-rcc.ads
@@ -1,0 +1,985 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x8.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+package Interfaces.STM32.RCC is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Registers --
+   ---------------
+
+   subtype CR_HSION_Field is Interfaces.STM32.Bit;
+   subtype CR_HSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSITRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR_HSICAL_Field is Interfaces.STM32.Byte;
+   subtype CR_HSEON_Field is Interfaces.STM32.Bit;
+   subtype CR_HSERDY_Field is Interfaces.STM32.Bit;
+   subtype CR_HSEBYP_Field is Interfaces.STM32.Bit;
+   subtype CR_CSSON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLON_Field is Interfaces.STM32.Bit;
+   subtype CR_PLLRDY_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register
+   type CR_Register is record
+      --  Internal High Speed clock enable
+      HSION          : CR_HSION_Field := 16#1#;
+      --  Read-only. Internal High Speed clock ready flag
+      HSIRDY         : CR_HSIRDY_Field := 16#1#;
+      --  unspecified
+      Reserved_2_2   : Interfaces.STM32.Bit := 16#0#;
+      --  Internal High Speed clock trimming
+      HSITRIM        : CR_HSITRIM_Field := 16#10#;
+      --  Read-only. Internal High Speed clock Calibration
+      HSICAL         : CR_HSICAL_Field := 16#0#;
+      --  External High Speed clock enable
+      HSEON          : CR_HSEON_Field := 16#0#;
+      --  Read-only. External High Speed clock ready flag
+      HSERDY         : CR_HSERDY_Field := 16#0#;
+      --  External High Speed clock Bypass
+      HSEBYP         : CR_HSEBYP_Field := 16#0#;
+      --  Clock Security System enable
+      CSSON          : CR_CSSON_Field := 16#0#;
+      --  unspecified
+      Reserved_20_23 : Interfaces.STM32.UInt4 := 16#0#;
+      --  PLL enable
+      PLLON          : CR_PLLON_Field := 16#0#;
+      --  Read-only. PLL clock ready flag
+      PLLRDY         : CR_PLLRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_26_31 : Interfaces.STM32.UInt6 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR_Register use record
+      HSION          at 0 range 0 .. 0;
+      HSIRDY         at 0 range 1 .. 1;
+      Reserved_2_2   at 0 range 2 .. 2;
+      HSITRIM        at 0 range 3 .. 7;
+      HSICAL         at 0 range 8 .. 15;
+      HSEON          at 0 range 16 .. 16;
+      HSERDY         at 0 range 17 .. 17;
+      HSEBYP         at 0 range 18 .. 18;
+      CSSON          at 0 range 19 .. 19;
+      Reserved_20_23 at 0 range 20 .. 23;
+      PLLON          at 0 range 24 .. 24;
+      PLLRDY         at 0 range 25 .. 25;
+      Reserved_26_31 at 0 range 26 .. 31;
+   end record;
+
+   subtype CFGR_SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_SWS_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_HPRE_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_PPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_ADCPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLSRC_Field is Interfaces.STM32.UInt2;
+   subtype CFGR_PLLXTPRE_Field is Interfaces.STM32.Bit;
+   subtype CFGR_PLLMUL_Field is Interfaces.STM32.UInt4;
+   subtype CFGR_MCO_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_MCOPRE_Field is Interfaces.STM32.UInt3;
+   subtype CFGR_PLLNODIV_Field is Interfaces.STM32.Bit;
+
+   --  Clock configuration register (RCC_CFGR)
+   type CFGR_Register is record
+      --  System clock Switch
+      SW             : CFGR_SW_Field := 16#0#;
+      --  Read-only. System Clock Switch Status
+      SWS            : CFGR_SWS_Field := 16#0#;
+      --  AHB prescaler
+      HPRE           : CFGR_HPRE_Field := 16#0#;
+      --  APB Low speed prescaler (APB1)
+      PPRE           : CFGR_PPRE_Field := 16#0#;
+      --  unspecified
+      Reserved_11_13 : Interfaces.STM32.UInt3 := 16#0#;
+      --  ADC prescaler
+      ADCPRE         : CFGR_ADCPRE_Field := 16#0#;
+      --  PLL input clock source
+      PLLSRC         : CFGR_PLLSRC_Field := 16#0#;
+      --  HSE divider for PLL entry
+      PLLXTPRE       : CFGR_PLLXTPRE_Field := 16#0#;
+      --  PLL Multiplication Factor
+      PLLMUL         : CFGR_PLLMUL_Field := 16#0#;
+      --  unspecified
+      Reserved_22_23 : Interfaces.STM32.UInt2 := 16#0#;
+      --  Microcontroller clock output
+      MCO            : CFGR_MCO_Field := 16#0#;
+      --  unspecified
+      Reserved_27_27 : Interfaces.STM32.Bit := 16#0#;
+      --  Microcontroller Clock Output Prescaler
+      MCOPRE         : CFGR_MCOPRE_Field := 16#0#;
+      --  PLL clock not divided for MCO
+      PLLNODIV       : CFGR_PLLNODIV_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR_Register use record
+      SW             at 0 range 0 .. 1;
+      SWS            at 0 range 2 .. 3;
+      HPRE           at 0 range 4 .. 7;
+      PPRE           at 0 range 8 .. 10;
+      Reserved_11_13 at 0 range 11 .. 13;
+      ADCPRE         at 0 range 14 .. 14;
+      PLLSRC         at 0 range 15 .. 16;
+      PLLXTPRE       at 0 range 17 .. 17;
+      PLLMUL         at 0 range 18 .. 21;
+      Reserved_22_23 at 0 range 22 .. 23;
+      MCO            at 0 range 24 .. 26;
+      Reserved_27_27 at 0 range 27 .. 27;
+      MCOPRE         at 0 range 28 .. 30;
+      PLLNODIV       at 0 range 31 .. 31;
+   end record;
+
+   subtype CIR_LSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYF_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSF_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYE_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYIE_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_LSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSIRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSERDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_PLLRDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI14RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_HSI48RDYC_Field is Interfaces.STM32.Bit;
+   subtype CIR_CSSC_Field is Interfaces.STM32.Bit;
+
+   --  Clock interrupt register (RCC_CIR)
+   type CIR_Register is record
+      --  Read-only. LSI Ready Interrupt flag
+      LSIRDYF        : CIR_LSIRDYF_Field := 16#0#;
+      --  Read-only. LSE Ready Interrupt flag
+      LSERDYF        : CIR_LSERDYF_Field := 16#0#;
+      --  Read-only. HSI Ready Interrupt flag
+      HSIRDYF        : CIR_HSIRDYF_Field := 16#0#;
+      --  Read-only. HSE Ready Interrupt flag
+      HSERDYF        : CIR_HSERDYF_Field := 16#0#;
+      --  Read-only. PLL Ready Interrupt flag
+      PLLRDYF        : CIR_PLLRDYF_Field := 16#0#;
+      --  Read-only. HSI14 ready interrupt flag
+      HSI14RDYF      : CIR_HSI14RDYF_Field := 16#0#;
+      --  Read-only. HSI48 ready interrupt flag
+      HSI48RDYF      : CIR_HSI48RDYF_Field := 16#0#;
+      --  Read-only. Clock Security System Interrupt flag
+      CSSF           : CIR_CSSF_Field := 16#0#;
+      --  LSI Ready Interrupt Enable
+      LSIRDYIE       : CIR_LSIRDYIE_Field := 16#0#;
+      --  LSE Ready Interrupt Enable
+      LSERDYIE       : CIR_LSERDYIE_Field := 16#0#;
+      --  HSI Ready Interrupt Enable
+      HSIRDYIE       : CIR_HSIRDYIE_Field := 16#0#;
+      --  HSE Ready Interrupt Enable
+      HSERDYIE       : CIR_HSERDYIE_Field := 16#0#;
+      --  PLL Ready Interrupt Enable
+      PLLRDYIE       : CIR_PLLRDYIE_Field := 16#0#;
+      --  HSI14 ready interrupt enable
+      HSI14RDYE      : CIR_HSI14RDYE_Field := 16#0#;
+      --  HSI48 ready interrupt enable
+      HSI48RDYIE     : CIR_HSI48RDYIE_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  Write-only. LSI Ready Interrupt Clear
+      LSIRDYC        : CIR_LSIRDYC_Field := 16#0#;
+      --  Write-only. LSE Ready Interrupt Clear
+      LSERDYC        : CIR_LSERDYC_Field := 16#0#;
+      --  Write-only. HSI Ready Interrupt Clear
+      HSIRDYC        : CIR_HSIRDYC_Field := 16#0#;
+      --  Write-only. HSE Ready Interrupt Clear
+      HSERDYC        : CIR_HSERDYC_Field := 16#0#;
+      --  Write-only. PLL Ready Interrupt Clear
+      PLLRDYC        : CIR_PLLRDYC_Field := 16#0#;
+      --  Write-only. HSI 14 MHz Ready Interrupt Clear
+      HSI14RDYC      : CIR_HSI14RDYC_Field := 16#0#;
+      --  Write-only. HSI48 Ready Interrupt Clear
+      HSI48RDYC      : CIR_HSI48RDYC_Field := 16#0#;
+      --  Write-only. Clock security system interrupt clear
+      CSSC           : CIR_CSSC_Field := 16#0#;
+      --  unspecified
+      Reserved_24_31 : Interfaces.STM32.Byte := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CIR_Register use record
+      LSIRDYF        at 0 range 0 .. 0;
+      LSERDYF        at 0 range 1 .. 1;
+      HSIRDYF        at 0 range 2 .. 2;
+      HSERDYF        at 0 range 3 .. 3;
+      PLLRDYF        at 0 range 4 .. 4;
+      HSI14RDYF      at 0 range 5 .. 5;
+      HSI48RDYF      at 0 range 6 .. 6;
+      CSSF           at 0 range 7 .. 7;
+      LSIRDYIE       at 0 range 8 .. 8;
+      LSERDYIE       at 0 range 9 .. 9;
+      HSIRDYIE       at 0 range 10 .. 10;
+      HSERDYIE       at 0 range 11 .. 11;
+      PLLRDYIE       at 0 range 12 .. 12;
+      HSI14RDYE      at 0 range 13 .. 13;
+      HSI48RDYIE     at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      LSIRDYC        at 0 range 16 .. 16;
+      LSERDYC        at 0 range 17 .. 17;
+      HSIRDYC        at 0 range 18 .. 18;
+      HSERDYC        at 0 range 19 .. 19;
+      PLLRDYC        at 0 range 20 .. 20;
+      HSI14RDYC      at 0 range 21 .. 21;
+      HSI48RDYC      at 0 range 22 .. 22;
+      CSSC           at 0 range 23 .. 23;
+      Reserved_24_31 at 0 range 24 .. 31;
+   end record;
+
+   subtype APB2RSTR_SYSCFGRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_ADCRST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_SPI1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_USART1RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM15RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM16RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_TIM17RST_Field is Interfaces.STM32.Bit;
+   subtype APB2RSTR_DBGMCURST_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral reset register (RCC_APB2RSTR)
+   type APB2RSTR_Register is record
+      --  SYSCFG and COMP reset
+      SYSCFGRST      : APB2RSTR_SYSCFGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_1_8   : Interfaces.STM32.Byte := 16#0#;
+      --  ADC interface reset
+      ADCRST         : APB2RSTR_ADCRST_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 timer reset
+      TIM1RST        : APB2RSTR_TIM1RST_Field := 16#0#;
+      --  SPI 1 reset
+      SPI1RST        : APB2RSTR_SPI1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 reset
+      USART1RST      : APB2RSTR_USART1RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer reset
+      TIM15RST       : APB2RSTR_TIM15RST_Field := 16#0#;
+      --  TIM16 timer reset
+      TIM16RST       : APB2RSTR_TIM16RST_Field := 16#0#;
+      --  TIM17 timer reset
+      TIM17RST       : APB2RSTR_TIM17RST_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  Debug MCU reset
+      DBGMCURST      : APB2RSTR_DBGMCURST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2RSTR_Register use record
+      SYSCFGRST      at 0 range 0 .. 0;
+      Reserved_1_8   at 0 range 1 .. 8;
+      ADCRST         at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1RST        at 0 range 11 .. 11;
+      SPI1RST        at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1RST      at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15RST       at 0 range 16 .. 16;
+      TIM16RST       at 0 range 17 .. 17;
+      TIM17RST       at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCURST      at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1RSTR_TIM2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM6RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM7RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_TIM14RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_WWDGRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_SPI2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART3RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART4RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USART5RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C1RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_I2C2RST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CANRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CRSRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_PWRRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_DACRST_Field is Interfaces.STM32.Bit;
+   subtype APB1RSTR_CECRST_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral reset register (RCC_APB1RSTR)
+   type APB1RSTR_Register is record
+      --  Timer 2 reset
+      TIM2RST        : APB1RSTR_TIM2RST_Field := 16#0#;
+      --  Timer 3 reset
+      TIM3RST        : APB1RSTR_TIM3RST_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 reset
+      TIM6RST        : APB1RSTR_TIM6RST_Field := 16#0#;
+      --  TIM7 timer reset
+      TIM7RST        : APB1RSTR_TIM7RST_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 reset
+      TIM14RST       : APB1RSTR_TIM14RST_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog reset
+      WWDGRST        : APB1RSTR_WWDGRST_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI2 reset
+      SPI2RST        : APB1RSTR_SPI2RST_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 reset
+      USART2RST      : APB1RSTR_USART2RST_Field := 16#0#;
+      --  USART3 reset
+      USART3RST      : APB1RSTR_USART3RST_Field := 16#0#;
+      --  USART4 reset
+      USART4RST      : APB1RSTR_USART4RST_Field := 16#0#;
+      --  USART5 reset
+      USART5RST      : APB1RSTR_USART5RST_Field := 16#0#;
+      --  I2C1 reset
+      I2C1RST        : APB1RSTR_I2C1RST_Field := 16#0#;
+      --  I2C2 reset
+      I2C2RST        : APB1RSTR_I2C2RST_Field := 16#0#;
+      --  USB interface reset
+      USBRST         : APB1RSTR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_24 : Interfaces.STM32.Bit := 16#0#;
+      --  CAN interface reset
+      CANRST         : APB1RSTR_CANRST_Field := 16#0#;
+      --  unspecified
+      Reserved_26_26 : Interfaces.STM32.Bit := 16#0#;
+      --  Clock Recovery System interface reset
+      CRSRST         : APB1RSTR_CRSRST_Field := 16#0#;
+      --  Power interface reset
+      PWRRST         : APB1RSTR_PWRRST_Field := 16#0#;
+      --  DAC interface reset
+      DACRST         : APB1RSTR_DACRST_Field := 16#0#;
+      --  HDMI CEC reset
+      CECRST         : APB1RSTR_CECRST_Field := 16#0#;
+      --  unspecified
+      Reserved_31_31 : Interfaces.STM32.Bit := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1RSTR_Register use record
+      TIM2RST        at 0 range 0 .. 0;
+      TIM3RST        at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6RST        at 0 range 4 .. 4;
+      TIM7RST        at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14RST       at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGRST        at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2RST        at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2RST      at 0 range 17 .. 17;
+      USART3RST      at 0 range 18 .. 18;
+      USART4RST      at 0 range 19 .. 19;
+      USART5RST      at 0 range 20 .. 20;
+      I2C1RST        at 0 range 21 .. 21;
+      I2C2RST        at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_24 at 0 range 24 .. 24;
+      CANRST         at 0 range 25 .. 25;
+      Reserved_26_26 at 0 range 26 .. 26;
+      CRSRST         at 0 range 27 .. 27;
+      PWRRST         at 0 range 28 .. 28;
+      DACRST         at 0 range 29 .. 29;
+      CECRST         at 0 range 30 .. 30;
+      Reserved_31_31 at 0 range 31 .. 31;
+   end record;
+
+   subtype AHBENR_DMA1EN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_DMA2EN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_SRAMEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_FLITFEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_CRCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPAEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPBEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPCEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPDEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_IOPFEN_Field is Interfaces.STM32.Bit;
+   subtype AHBENR_TSCEN_Field is Interfaces.STM32.Bit;
+
+   --  AHB Peripheral Clock enable register (RCC_AHBENR)
+   type AHBENR_Register is record
+      --  DMA1 clock enable
+      DMA1EN         : AHBENR_DMA1EN_Field := 16#0#;
+      --  DMA2 clock enable
+      DMA2EN         : AHBENR_DMA2EN_Field := 16#0#;
+      --  SRAM interface clock enable
+      SRAMEN         : AHBENR_SRAMEN_Field := 16#1#;
+      --  unspecified
+      Reserved_3_3   : Interfaces.STM32.Bit := 16#0#;
+      --  FLITF clock enable
+      FLITFEN        : AHBENR_FLITFEN_Field := 16#1#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  CRC clock enable
+      CRCEN          : AHBENR_CRCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_7_16  : Interfaces.STM32.UInt10 := 16#0#;
+      --  I/O port A clock enable
+      IOPAEN         : AHBENR_IOPAEN_Field := 16#0#;
+      --  I/O port B clock enable
+      IOPBEN         : AHBENR_IOPBEN_Field := 16#0#;
+      --  I/O port C clock enable
+      IOPCEN         : AHBENR_IOPCEN_Field := 16#0#;
+      --  I/O port D clock enable
+      IOPDEN         : AHBENR_IOPDEN_Field := 16#0#;
+      --  unspecified
+      Reserved_21_21 : Interfaces.STM32.Bit := 16#0#;
+      --  I/O port F clock enable
+      IOPFEN         : AHBENR_IOPFEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_23 : Interfaces.STM32.Bit := 16#0#;
+      --  Touch sensing controller clock enable
+      TSCEN          : AHBENR_TSCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBENR_Register use record
+      DMA1EN         at 0 range 0 .. 0;
+      DMA2EN         at 0 range 1 .. 1;
+      SRAMEN         at 0 range 2 .. 2;
+      Reserved_3_3   at 0 range 3 .. 3;
+      FLITFEN        at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CRCEN          at 0 range 6 .. 6;
+      Reserved_7_16  at 0 range 7 .. 16;
+      IOPAEN         at 0 range 17 .. 17;
+      IOPBEN         at 0 range 18 .. 18;
+      IOPCEN         at 0 range 19 .. 19;
+      IOPDEN         at 0 range 20 .. 20;
+      Reserved_21_21 at 0 range 21 .. 21;
+      IOPFEN         at 0 range 22 .. 22;
+      Reserved_23_23 at 0 range 23 .. 23;
+      TSCEN          at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   subtype APB2ENR_SYSCFGEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_ADCEN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_SPI1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_USART1EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM15EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM16EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_TIM17EN_Field is Interfaces.STM32.Bit;
+   subtype APB2ENR_DBGMCUEN_Field is Interfaces.STM32.Bit;
+
+   --  APB2 peripheral clock enable register (RCC_APB2ENR)
+   type APB2ENR_Register is record
+      --  SYSCFG clock enable
+      SYSCFGEN       : APB2ENR_SYSCFGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_1_8   : Interfaces.STM32.Byte := 16#0#;
+      --  ADC 1 interface clock enable
+      ADCEN          : APB2ENR_ADCEN_Field := 16#0#;
+      --  unspecified
+      Reserved_10_10 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM1 Timer clock enable
+      TIM1EN         : APB2ENR_TIM1EN_Field := 16#0#;
+      --  SPI 1 clock enable
+      SPI1EN         : APB2ENR_SPI1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_13_13 : Interfaces.STM32.Bit := 16#0#;
+      --  USART1 clock enable
+      USART1EN       : APB2ENR_USART1EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_15 : Interfaces.STM32.Bit := 16#0#;
+      --  TIM15 timer clock enable
+      TIM15EN        : APB2ENR_TIM15EN_Field := 16#0#;
+      --  TIM16 timer clock enable
+      TIM16EN        : APB2ENR_TIM16EN_Field := 16#0#;
+      --  TIM17 timer clock enable
+      TIM17EN        : APB2ENR_TIM17EN_Field := 16#0#;
+      --  unspecified
+      Reserved_19_21 : Interfaces.STM32.UInt3 := 16#0#;
+      --  MCU debug module clock enable
+      DBGMCUEN       : APB2ENR_DBGMCUEN_Field := 16#0#;
+      --  unspecified
+      Reserved_23_31 : Interfaces.STM32.UInt9 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB2ENR_Register use record
+      SYSCFGEN       at 0 range 0 .. 0;
+      Reserved_1_8   at 0 range 1 .. 8;
+      ADCEN          at 0 range 9 .. 9;
+      Reserved_10_10 at 0 range 10 .. 10;
+      TIM1EN         at 0 range 11 .. 11;
+      SPI1EN         at 0 range 12 .. 12;
+      Reserved_13_13 at 0 range 13 .. 13;
+      USART1EN       at 0 range 14 .. 14;
+      Reserved_15_15 at 0 range 15 .. 15;
+      TIM15EN        at 0 range 16 .. 16;
+      TIM16EN        at 0 range 17 .. 17;
+      TIM17EN        at 0 range 18 .. 18;
+      Reserved_19_21 at 0 range 19 .. 21;
+      DBGMCUEN       at 0 range 22 .. 22;
+      Reserved_23_31 at 0 range 23 .. 31;
+   end record;
+
+   subtype APB1ENR_TIM2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM6EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM7EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_TIM14EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_WWDGEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_SPI2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART3EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART4EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USART5EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C1EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_I2C2EN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_USBRST_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CANEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CRSEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_PWREN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_DACEN_Field is Interfaces.STM32.Bit;
+   subtype APB1ENR_CECEN_Field is Interfaces.STM32.Bit;
+
+   --  APB1 peripheral clock enable register (RCC_APB1ENR)
+   type APB1ENR_Register is record
+      --  Timer 2 clock enable
+      TIM2EN         : APB1ENR_TIM2EN_Field := 16#0#;
+      --  Timer 3 clock enable
+      TIM3EN         : APB1ENR_TIM3EN_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 6 clock enable
+      TIM6EN         : APB1ENR_TIM6EN_Field := 16#0#;
+      --  TIM7 timer clock enable
+      TIM7EN         : APB1ENR_TIM7EN_Field := 16#0#;
+      --  unspecified
+      Reserved_6_7   : Interfaces.STM32.UInt2 := 16#0#;
+      --  Timer 14 clock enable
+      TIM14EN        : APB1ENR_TIM14EN_Field := 16#0#;
+      --  unspecified
+      Reserved_9_10  : Interfaces.STM32.UInt2 := 16#0#;
+      --  Window watchdog clock enable
+      WWDGEN         : APB1ENR_WWDGEN_Field := 16#0#;
+      --  unspecified
+      Reserved_12_13 : Interfaces.STM32.UInt2 := 16#0#;
+      --  SPI 2 clock enable
+      SPI2EN         : APB1ENR_SPI2EN_Field := 16#0#;
+      --  unspecified
+      Reserved_15_16 : Interfaces.STM32.UInt2 := 16#0#;
+      --  USART 2 clock enable
+      USART2EN       : APB1ENR_USART2EN_Field := 16#0#;
+      --  USART3 clock enable
+      USART3EN       : APB1ENR_USART3EN_Field := 16#0#;
+      --  USART4 clock enable
+      USART4EN       : APB1ENR_USART4EN_Field := 16#0#;
+      --  USART5 clock enable
+      USART5EN       : APB1ENR_USART5EN_Field := 16#0#;
+      --  I2C 1 clock enable
+      I2C1EN         : APB1ENR_I2C1EN_Field := 16#0#;
+      --  I2C 2 clock enable
+      I2C2EN         : APB1ENR_I2C2EN_Field := 16#0#;
+      --  USB interface clock enable
+      USBRST         : APB1ENR_USBRST_Field := 16#0#;
+      --  unspecified
+      Reserved_24_24 : Interfaces.STM32.Bit := 16#0#;
+      --  CAN interface clock enable
+      CANEN          : APB1ENR_CANEN_Field := 16#0#;
+      --  unspecified
+      Reserved_26_26 : Interfaces.STM32.Bit := 16#0#;
+      --  Clock Recovery System interface clock enable
+      CRSEN          : APB1ENR_CRSEN_Field := 16#0#;
+      --  Power interface clock enable
+      PWREN          : APB1ENR_PWREN_Field := 16#0#;
+      --  DAC interface clock enable
+      DACEN          : APB1ENR_DACEN_Field := 16#0#;
+      --  HDMI CEC interface clock enable
+      CECEN          : APB1ENR_CECEN_Field := 16#0#;
+      --  unspecified
+      Reserved_31_31 : Interfaces.STM32.Bit := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for APB1ENR_Register use record
+      TIM2EN         at 0 range 0 .. 0;
+      TIM3EN         at 0 range 1 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      TIM6EN         at 0 range 4 .. 4;
+      TIM7EN         at 0 range 5 .. 5;
+      Reserved_6_7   at 0 range 6 .. 7;
+      TIM14EN        at 0 range 8 .. 8;
+      Reserved_9_10  at 0 range 9 .. 10;
+      WWDGEN         at 0 range 11 .. 11;
+      Reserved_12_13 at 0 range 12 .. 13;
+      SPI2EN         at 0 range 14 .. 14;
+      Reserved_15_16 at 0 range 15 .. 16;
+      USART2EN       at 0 range 17 .. 17;
+      USART3EN       at 0 range 18 .. 18;
+      USART4EN       at 0 range 19 .. 19;
+      USART5EN       at 0 range 20 .. 20;
+      I2C1EN         at 0 range 21 .. 21;
+      I2C2EN         at 0 range 22 .. 22;
+      USBRST         at 0 range 23 .. 23;
+      Reserved_24_24 at 0 range 24 .. 24;
+      CANEN          at 0 range 25 .. 25;
+      Reserved_26_26 at 0 range 26 .. 26;
+      CRSEN          at 0 range 27 .. 27;
+      PWREN          at 0 range 28 .. 28;
+      DACEN          at 0 range 29 .. 29;
+      CECEN          at 0 range 30 .. 30;
+      Reserved_31_31 at 0 range 31 .. 31;
+   end record;
+
+   subtype BDCR_LSEON_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSERDY_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEBYP_Field is Interfaces.STM32.Bit;
+   subtype BDCR_LSEDRV_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCSEL_Field is Interfaces.STM32.UInt2;
+   subtype BDCR_RTCEN_Field is Interfaces.STM32.Bit;
+   subtype BDCR_BDRST_Field is Interfaces.STM32.Bit;
+
+   --  Backup domain control register (RCC_BDCR)
+   type BDCR_Register is record
+      --  External Low Speed oscillator enable
+      LSEON          : BDCR_LSEON_Field := 16#0#;
+      --  Read-only. External Low Speed oscillator ready
+      LSERDY         : BDCR_LSERDY_Field := 16#0#;
+      --  External Low Speed oscillator bypass
+      LSEBYP         : BDCR_LSEBYP_Field := 16#0#;
+      --  LSE oscillator drive capability
+      LSEDRV         : BDCR_LSEDRV_Field := 16#0#;
+      --  unspecified
+      Reserved_5_7   : Interfaces.STM32.UInt3 := 16#0#;
+      --  RTC clock source selection
+      RTCSEL         : BDCR_RTCSEL_Field := 16#0#;
+      --  unspecified
+      Reserved_10_14 : Interfaces.STM32.UInt5 := 16#0#;
+      --  RTC clock enable
+      RTCEN          : BDCR_RTCEN_Field := 16#0#;
+      --  Backup domain software reset
+      BDRST          : BDCR_BDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_17_31 : Interfaces.STM32.UInt15 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for BDCR_Register use record
+      LSEON          at 0 range 0 .. 0;
+      LSERDY         at 0 range 1 .. 1;
+      LSEBYP         at 0 range 2 .. 2;
+      LSEDRV         at 0 range 3 .. 4;
+      Reserved_5_7   at 0 range 5 .. 7;
+      RTCSEL         at 0 range 8 .. 9;
+      Reserved_10_14 at 0 range 10 .. 14;
+      RTCEN          at 0 range 15 .. 15;
+      BDRST          at 0 range 16 .. 16;
+      Reserved_17_31 at 0 range 17 .. 31;
+   end record;
+
+   subtype CSR_LSION_Field is Interfaces.STM32.Bit;
+   subtype CSR_LSIRDY_Field is Interfaces.STM32.Bit;
+   subtype CSR_RMVF_Field is Interfaces.STM32.Bit;
+   subtype CSR_OBLRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PINRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_PORRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_SFTRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_IWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_WWDGRSTF_Field is Interfaces.STM32.Bit;
+   subtype CSR_LPWRRSTF_Field is Interfaces.STM32.Bit;
+
+   --  Control/status register (RCC_CSR)
+   type CSR_Register is record
+      --  Internal low speed oscillator enable
+      LSION         : CSR_LSION_Field := 16#0#;
+      --  Read-only. Internal low speed oscillator ready
+      LSIRDY        : CSR_LSIRDY_Field := 16#0#;
+      --  unspecified
+      Reserved_2_23 : Interfaces.STM32.UInt22 := 16#0#;
+      --  Remove reset flag
+      RMVF          : CSR_RMVF_Field := 16#0#;
+      --  Option byte loader reset flag
+      OBLRSTF       : CSR_OBLRSTF_Field := 16#0#;
+      --  PIN reset flag
+      PINRSTF       : CSR_PINRSTF_Field := 16#1#;
+      --  POR/PDR reset flag
+      PORRSTF       : CSR_PORRSTF_Field := 16#1#;
+      --  Software reset flag
+      SFTRSTF       : CSR_SFTRSTF_Field := 16#0#;
+      --  Independent watchdog reset flag
+      IWDGRSTF      : CSR_IWDGRSTF_Field := 16#0#;
+      --  Window watchdog reset flag
+      WWDGRSTF      : CSR_WWDGRSTF_Field := 16#0#;
+      --  Low-power reset flag
+      LPWRRSTF      : CSR_LPWRRSTF_Field := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CSR_Register use record
+      LSION         at 0 range 0 .. 0;
+      LSIRDY        at 0 range 1 .. 1;
+      Reserved_2_23 at 0 range 2 .. 23;
+      RMVF          at 0 range 24 .. 24;
+      OBLRSTF       at 0 range 25 .. 25;
+      PINRSTF       at 0 range 26 .. 26;
+      PORRSTF       at 0 range 27 .. 27;
+      SFTRSTF       at 0 range 28 .. 28;
+      IWDGRSTF      at 0 range 29 .. 29;
+      WWDGRSTF      at 0 range 30 .. 30;
+      LPWRRSTF      at 0 range 31 .. 31;
+   end record;
+
+   subtype AHBRSTR_IOPARST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPBRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPCRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPDRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_IOPFRST_Field is Interfaces.STM32.Bit;
+   subtype AHBRSTR_TSCRST_Field is Interfaces.STM32.Bit;
+
+   --  AHB peripheral reset register
+   type AHBRSTR_Register is record
+      --  unspecified
+      Reserved_0_16  : Interfaces.STM32.UInt17 := 16#0#;
+      --  I/O port A reset
+      IOPARST        : AHBRSTR_IOPARST_Field := 16#0#;
+      --  I/O port B reset
+      IOPBRST        : AHBRSTR_IOPBRST_Field := 16#0#;
+      --  I/O port C reset
+      IOPCRST        : AHBRSTR_IOPCRST_Field := 16#0#;
+      --  I/O port D reset
+      IOPDRST        : AHBRSTR_IOPDRST_Field := 16#0#;
+      --  unspecified
+      Reserved_21_21 : Interfaces.STM32.Bit := 16#0#;
+      --  I/O port F reset
+      IOPFRST        : AHBRSTR_IOPFRST_Field := 16#0#;
+      --  unspecified
+      Reserved_23_23 : Interfaces.STM32.Bit := 16#0#;
+      --  Touch sensing controller reset
+      TSCRST         : AHBRSTR_TSCRST_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for AHBRSTR_Register use record
+      Reserved_0_16  at 0 range 0 .. 16;
+      IOPARST        at 0 range 17 .. 17;
+      IOPBRST        at 0 range 18 .. 18;
+      IOPCRST        at 0 range 19 .. 19;
+      IOPDRST        at 0 range 20 .. 20;
+      Reserved_21_21 at 0 range 21 .. 21;
+      IOPFRST        at 0 range 22 .. 22;
+      Reserved_23_23 at 0 range 23 .. 23;
+      TSCRST         at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   subtype CFGR2_PREDIV_Field is Interfaces.STM32.UInt4;
+
+   --  Clock configuration register 2
+   type CFGR2_Register is record
+      --  PREDIV division factor
+      PREDIV        : CFGR2_PREDIV_Field := 16#0#;
+      --  unspecified
+      Reserved_4_31 : Interfaces.STM32.UInt28 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR2_Register use record
+      PREDIV        at 0 range 0 .. 3;
+      Reserved_4_31 at 0 range 4 .. 31;
+   end record;
+
+   subtype CFGR3_USART1SW_Field is Interfaces.STM32.UInt2;
+   subtype CFGR3_I2C1SW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_CECSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USBSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_ADCSW_Field is Interfaces.STM32.Bit;
+   subtype CFGR3_USART2SW_Field is Interfaces.STM32.UInt2;
+
+   --  Clock configuration register 3
+   type CFGR3_Register is record
+      --  USART1 clock source selection
+      USART1SW       : CFGR3_USART1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_2_3   : Interfaces.STM32.UInt2 := 16#0#;
+      --  I2C1 clock source selection
+      I2C1SW         : CFGR3_I2C1SW_Field := 16#0#;
+      --  unspecified
+      Reserved_5_5   : Interfaces.STM32.Bit := 16#0#;
+      --  HDMI CEC clock source selection
+      CECSW          : CFGR3_CECSW_Field := 16#0#;
+      --  USB clock source selection
+      USBSW          : CFGR3_USBSW_Field := 16#0#;
+      --  ADC clock source selection
+      ADCSW          : CFGR3_ADCSW_Field := 16#0#;
+      --  unspecified
+      Reserved_9_15  : Interfaces.STM32.UInt7 := 16#0#;
+      --  USART2 clock source selection
+      USART2SW       : CFGR3_USART2SW_Field := 16#0#;
+      --  unspecified
+      Reserved_18_31 : Interfaces.STM32.UInt14 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CFGR3_Register use record
+      USART1SW       at 0 range 0 .. 1;
+      Reserved_2_3   at 0 range 2 .. 3;
+      I2C1SW         at 0 range 4 .. 4;
+      Reserved_5_5   at 0 range 5 .. 5;
+      CECSW          at 0 range 6 .. 6;
+      USBSW          at 0 range 7 .. 7;
+      ADCSW          at 0 range 8 .. 8;
+      Reserved_9_15  at 0 range 9 .. 15;
+      USART2SW       at 0 range 16 .. 17;
+      Reserved_18_31 at 0 range 18 .. 31;
+   end record;
+
+   subtype CR2_HSI14ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14DIS_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI14TRIM_Field is Interfaces.STM32.UInt5;
+   subtype CR2_HSI14CAL_Field is Interfaces.STM32.Byte;
+   subtype CR2_HSI48ON_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48RDY_Field is Interfaces.STM32.Bit;
+   subtype CR2_HSI48CAL_Field is Interfaces.STM32.Bit;
+
+   --  Clock control register 2
+   type CR2_Register is record
+      --  HSI14 clock enable
+      HSI14ON        : CR2_HSI14ON_Field := 16#0#;
+      --  Read-only. HR14 clock ready flag
+      HSI14RDY       : CR2_HSI14RDY_Field := 16#0#;
+      --  HSI14 clock request from ADC disable
+      HSI14DIS       : CR2_HSI14DIS_Field := 16#0#;
+      --  HSI14 clock trimming
+      HSI14TRIM      : CR2_HSI14TRIM_Field := 16#10#;
+      --  Read-only. HSI14 clock calibration
+      HSI14CAL       : CR2_HSI14CAL_Field := 16#0#;
+      --  HSI48 clock enable
+      HSI48ON        : CR2_HSI48ON_Field := 16#0#;
+      --  Read-only. HSI48 clock ready flag
+      HSI48RDY       : CR2_HSI48RDY_Field := 16#0#;
+      --  unspecified
+      Reserved_18_23 : Interfaces.STM32.UInt6 := 16#0#;
+      --  Read-only. HSI48 factory clock calibration
+      HSI48CAL       : CR2_HSI48CAL_Field := 16#0#;
+      --  unspecified
+      Reserved_25_31 : Interfaces.STM32.UInt7 := 16#0#;
+   end record
+     with Volatile_Full_Access, Object_Size => 32,
+          Bit_Order => System.Low_Order_First;
+
+   for CR2_Register use record
+      HSI14ON        at 0 range 0 .. 0;
+      HSI14RDY       at 0 range 1 .. 1;
+      HSI14DIS       at 0 range 2 .. 2;
+      HSI14TRIM      at 0 range 3 .. 7;
+      HSI14CAL       at 0 range 8 .. 15;
+      HSI48ON        at 0 range 16 .. 16;
+      HSI48RDY       at 0 range 17 .. 17;
+      Reserved_18_23 at 0 range 18 .. 23;
+      HSI48CAL       at 0 range 24 .. 24;
+      Reserved_25_31 at 0 range 25 .. 31;
+   end record;
+
+   -----------------
+   -- Peripherals --
+   -----------------
+
+   --  Reset and clock control
+   type RCC_Peripheral is record
+      --  Clock control register
+      CR       : aliased CR_Register;
+      --  Clock configuration register (RCC_CFGR)
+      CFGR     : aliased CFGR_Register;
+      --  Clock interrupt register (RCC_CIR)
+      CIR      : aliased CIR_Register;
+      --  APB2 peripheral reset register (RCC_APB2RSTR)
+      APB2RSTR : aliased APB2RSTR_Register;
+      --  APB1 peripheral reset register (RCC_APB1RSTR)
+      APB1RSTR : aliased APB1RSTR_Register;
+      --  AHB Peripheral Clock enable register (RCC_AHBENR)
+      AHBENR   : aliased AHBENR_Register;
+      --  APB2 peripheral clock enable register (RCC_APB2ENR)
+      APB2ENR  : aliased APB2ENR_Register;
+      --  APB1 peripheral clock enable register (RCC_APB1ENR)
+      APB1ENR  : aliased APB1ENR_Register;
+      --  Backup domain control register (RCC_BDCR)
+      BDCR     : aliased BDCR_Register;
+      --  Control/status register (RCC_CSR)
+      CSR      : aliased CSR_Register;
+      --  AHB peripheral reset register
+      AHBRSTR  : aliased AHBRSTR_Register;
+      --  Clock configuration register 2
+      CFGR2    : aliased CFGR2_Register;
+      --  Clock configuration register 3
+      CFGR3    : aliased CFGR3_Register;
+      --  Clock control register 2
+      CR2      : aliased CR2_Register;
+   end record
+     with Volatile;
+
+   for RCC_Peripheral use record
+      CR       at 16#0# range 0 .. 31;
+      CFGR     at 16#4# range 0 .. 31;
+      CIR      at 16#8# range 0 .. 31;
+      APB2RSTR at 16#C# range 0 .. 31;
+      APB1RSTR at 16#10# range 0 .. 31;
+      AHBENR   at 16#14# range 0 .. 31;
+      APB2ENR  at 16#18# range 0 .. 31;
+      APB1ENR  at 16#1C# range 0 .. 31;
+      BDCR     at 16#20# range 0 .. 31;
+      CSR      at 16#24# range 0 .. 31;
+      AHBRSTR  at 16#28# range 0 .. 31;
+      CFGR2    at 16#2C# range 0 .. 31;
+      CFGR3    at 16#30# range 0 .. 31;
+      CR2      at 16#34# range 0 .. 31;
+   end record;
+
+   --  Reset and clock control
+   RCC_Periph : aliased RCC_Peripheral
+     with Import, Address => RCC_Base;
+
+end Interfaces.STM32.RCC;

--- a/arm/stm32/stm32f0xx/stm32f0x8/svd/i-stm32.ads
+++ b/arm/stm32/stm32f0xx/stm32f0x8/svd/i-stm32.ads
@@ -1,0 +1,137 @@
+--
+--  Copyright (C) 2020, AdaCore
+--
+
+--  This spec has been automatically generated from STM32F0x8.svd
+
+pragma Ada_2012;
+pragma Style_Checks (Off);
+
+with System;
+
+--  STM32F0x8
+package Interfaces.STM32 is
+   pragma Preelaborate;
+   pragma No_Elaboration_Code_All;
+
+   ---------------
+   -- Base type --
+   ---------------
+
+   type UInt32 is new Interfaces.Unsigned_32;
+   type UInt16 is new Interfaces.Unsigned_16;
+   type Byte is new Interfaces.Unsigned_8;
+   type Bit is mod 2**1
+     with Size => 1;
+   type UInt2 is mod 2**2
+     with Size => 2;
+   type UInt3 is mod 2**3
+     with Size => 3;
+   type UInt4 is mod 2**4
+     with Size => 4;
+   type UInt5 is mod 2**5
+     with Size => 5;
+   type UInt6 is mod 2**6
+     with Size => 6;
+   type UInt7 is mod 2**7
+     with Size => 7;
+   type UInt9 is mod 2**9
+     with Size => 9;
+   type UInt10 is mod 2**10
+     with Size => 10;
+   type UInt11 is mod 2**11
+     with Size => 11;
+   type UInt12 is mod 2**12
+     with Size => 12;
+   type UInt13 is mod 2**13
+     with Size => 13;
+   type UInt14 is mod 2**14
+     with Size => 14;
+   type UInt15 is mod 2**15
+     with Size => 15;
+   type UInt17 is mod 2**17
+     with Size => 17;
+   type UInt18 is mod 2**18
+     with Size => 18;
+   type UInt19 is mod 2**19
+     with Size => 19;
+   type UInt20 is mod 2**20
+     with Size => 20;
+   type UInt21 is mod 2**21
+     with Size => 21;
+   type UInt22 is mod 2**22
+     with Size => 22;
+   type UInt23 is mod 2**23
+     with Size => 23;
+   type UInt24 is mod 2**24
+     with Size => 24;
+   type UInt25 is mod 2**25
+     with Size => 25;
+   type UInt26 is mod 2**26
+     with Size => 26;
+   type UInt27 is mod 2**27
+     with Size => 27;
+   type UInt28 is mod 2**28
+     with Size => 28;
+   type UInt29 is mod 2**29
+     with Size => 29;
+   type UInt30 is mod 2**30
+     with Size => 30;
+   type UInt31 is mod 2**31
+     with Size => 31;
+
+   --------------------
+   -- Base addresses --
+   --------------------
+
+   CRC_Base : constant System.Address := System'To_Address (16#40023000#);
+   GPIOF_Base : constant System.Address := System'To_Address (16#48001400#);
+   GPIOD_Base : constant System.Address := System'To_Address (16#48000C00#);
+   GPIOC_Base : constant System.Address := System'To_Address (16#48000800#);
+   GPIOB_Base : constant System.Address := System'To_Address (16#48000400#);
+   GPIOE_Base : constant System.Address := System'To_Address (16#48001000#);
+   GPIOA_Base : constant System.Address := System'To_Address (16#48000000#);
+   SPI1_Base : constant System.Address := System'To_Address (16#40013000#);
+   SPI2_Base : constant System.Address := System'To_Address (16#40003800#);
+   PWR_Base : constant System.Address := System'To_Address (16#40007000#);
+   I2C1_Base : constant System.Address := System'To_Address (16#40005400#);
+   I2C2_Base : constant System.Address := System'To_Address (16#40005800#);
+   IWDG_Base : constant System.Address := System'To_Address (16#40003000#);
+   WWDG_Base : constant System.Address := System'To_Address (16#40002C00#);
+   TIM1_Base : constant System.Address := System'To_Address (16#40012C00#);
+   TIM2_Base : constant System.Address := System'To_Address (16#40000000#);
+   TIM3_Base : constant System.Address := System'To_Address (16#40000400#);
+   TIM14_Base : constant System.Address := System'To_Address (16#40002000#);
+   TIM6_Base : constant System.Address := System'To_Address (16#40001000#);
+   TIM7_Base : constant System.Address := System'To_Address (16#40001400#);
+   EXTI_Base : constant System.Address := System'To_Address (16#40010400#);
+   NVIC_Base : constant System.Address := System'To_Address (16#E000E100#);
+   DMA1_Base : constant System.Address := System'To_Address (16#40020000#);
+   DMA2_Base : constant System.Address := System'To_Address (16#40020400#);
+   RCC_Base : constant System.Address := System'To_Address (16#40021000#);
+   SYSCFG_COMP_Base : constant System.Address := System'To_Address (16#40010000#);
+   ADC_Base : constant System.Address := System'To_Address (16#40012400#);
+   USART1_Base : constant System.Address := System'To_Address (16#40013800#);
+   USART2_Base : constant System.Address := System'To_Address (16#40004400#);
+   USART3_Base : constant System.Address := System'To_Address (16#40004800#);
+   USART4_Base : constant System.Address := System'To_Address (16#40004C00#);
+   USART6_Base : constant System.Address := System'To_Address (16#40011400#);
+   USART7_Base : constant System.Address := System'To_Address (16#40011800#);
+   USART8_Base : constant System.Address := System'To_Address (16#40011C00#);
+   USART5_Base : constant System.Address := System'To_Address (16#40005000#);
+   RTC_Base : constant System.Address := System'To_Address (16#40002800#);
+   TIM15_Base : constant System.Address := System'To_Address (16#40014000#);
+   TIM16_Base : constant System.Address := System'To_Address (16#40014400#);
+   TIM17_Base : constant System.Address := System'To_Address (16#40014800#);
+   TSC_Base : constant System.Address := System'To_Address (16#40024000#);
+   CEC_Base : constant System.Address := System'To_Address (16#40007800#);
+   Flash_Base : constant System.Address := System'To_Address (16#40022000#);
+   DBGMCU_Base : constant System.Address := System'To_Address (16#40015800#);
+   USB_Base : constant System.Address := System'To_Address (16#40005C00#);
+   CRS_Base : constant System.Address := System'To_Address (16#40006C00#);
+   CAN_Base : constant System.Address := System'To_Address (16#40006400#);
+   DAC_Base : constant System.Address := System'To_Address (16#40007400#);
+   SCB_Base : constant System.Address := System'To_Address (16#E000ED00#);
+   STK_Base : constant System.Address := System'To_Address (16#E000E010#);
+
+end Interfaces.STM32;

--- a/arm/stm32/stm32f0xx/svd.mk
+++ b/arm/stm32/stm32f0xx/svd.mk
@@ -1,0 +1,24 @@
+SVD2ADA_DIR=$(shell dirname $(shell which svd2ada))
+
+all: svd
+
+svd:
+	rm -rf */svd */svdtmp
+	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F0x0.svd \
+	  -o stm32f0x0/svdtmp -p Interfaces.STM32
+	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F0x1.svd \
+	  -o stm32f0x1/svdtmp -p Interfaces.STM32
+	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F0x2.svd \
+	  -o stm32f0x2/svdtmp -p Interfaces.STM32
+	$(SVD2ADA_DIR)/svd2ada $(SVD2ADA_DIR)/CMSIS-SVD/ST/STM32F0x8.svd \
+	  -o stm32f0x8/svdtmp -p Interfaces.STM32
+	for d in */svdtmp; do \
+	   cd $$d; \
+	   mkdir ../svd; \
+	   mv i-stm32.ads ../svd; \
+	   mv i-stm32-flash.ads ../svd; \
+	   mv i-stm32-rcc.ads ../svd; \
+	   mv a-intnam.ads ../svd; \
+	   cd ../..; \
+	done
+	rm -rf */svdtmp

--- a/build_rts.py
+++ b/build_rts.py
@@ -16,7 +16,7 @@ from pikeos import ArmPikeOS, ArmPikeOS42, ArmPikeOS5
 
 # Cortex-M runtimes
 from arm.cortexm import Stm32, Sam, SmartFusion2, LM3S, Microbit, \
-     NRF52840, NRF52832, MicrosemiM1, \
+     NRF52840, NRF52832, MicrosemiM1, Stm32F0, \
      CortexM0, CortexM0P, CortexM1, CortexM3, CortexM4, CortexM4F, \
      CortexM7F, CortexM7DF
 
@@ -76,6 +76,8 @@ def build_configs(target):
         t = Sam(target)
     elif target.startswith('smartfusion2'):
         t = SmartFusion2()
+    elif target.startswith('stm32f0'):
+        t = Stm32F0(target)
     elif target.startswith('stm32'):
         t = Stm32(target)
     elif target == 'feather_stm32f405':

--- a/src/s-bbpara__cortexm0.ads
+++ b/src/s-bbpara__cortexm0.ads
@@ -1,0 +1,125 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                  GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                --
+--                                                                          --
+--                   S Y S T E M . B B . P A R A M E T E R S                --
+--                                                                          --
+--                                  S p e c                                 --
+--                                                                          --
+--        Copyright (C) 1999-2002 Universidad Politecnica de Madrid         --
+--             Copyright (C) 2003-2005 The European Space Agency            --
+--                     Copyright (C) 2003-2019, AdaCore                     --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+-- The port of GNARL to bare board targets was initially developed by the   --
+-- Real-Time Systems Group at the Technical University of Madrid.           --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package defines basic parameters used by the low level tasking system
+
+--  This is the Arm Cortex-M0 (ARMv6-M) version of this package
+
+with System.BB.Board_Parameters;
+with System.BB.MCU_Parameters;
+
+package System.BB.Parameters is
+   pragma No_Elaboration_Code_All;
+   pragma Preelaborate (System.BB.Parameters);
+
+   Clock_Frequency  : constant := Board_Parameters.Main_Clock_Frequency;
+   Ticks_Per_Second : constant := Board_Parameters.Main_Clock_Frequency;
+
+   ----------------
+   -- Interrupts --
+   ----------------
+
+   --  These definitions are in this package in order to isolate target
+   --  dependencies.
+
+   subtype Interrupt_Range is Integer
+     range -1 .. MCU_Parameters.Number_Of_Interrupts;
+   --  Number of interrupts for the interrupt controller
+
+   Trap_Vectors : constant := 17;
+   --  While on this target there is little difference between interrupts
+   --  and traps, we consider the following traps:
+   --
+   --    Name                        Nr
+   --
+   --    Reset_Vector                 1
+   --    NMI_Vector                   2
+   --    Hard_Fault_Vector            3
+   --    Mem_Manage_Vector            4
+   --    Bus_Fault_Vector             5
+   --    Usage_Fault_Vector           6
+   --    SVC_Vector                  11
+   --    Debug_Mon_Vector            12
+   --    Pend_SV_Vector              14
+   --    Sys_Tick_Vector             15
+   --    Interrupt_Request_Vector    16
+   --
+   --  These trap vectors correspond to different low-level trap handlers in
+   --  the run time. Note that as all interrupt requests (IRQs) will use the
+   --  same interrupt wrapper, there is no benefit to consider using separate
+   --  vectors for each.
+
+   Context_Buffer_Capacity : constant := 10;
+   --  The context buffer contains registers r4 .. r11 and the SP_process
+   --  (PSP). The size is rounded up to an even number for alignment
+
+   ------------
+   -- Stacks --
+   ------------
+
+   Interrupt_Stack_Size : constant := 1024;
+   --  Size of each of the interrupt stacks in bytes. While there nominally is
+   --  an interrupt stack per interrupt priority, the entire space is used as a
+   --  single stack.
+
+   Interrupt_Sec_Stack_Size : constant := 128;
+   --  Size of the secondary stack for interrupt handlers
+
+   Has_FPU : constant Boolean := False;
+   --  Set to true if core has a FPU
+
+   Has_VTOR : constant Boolean := False;
+   --  Set to true if core has a Vector Table Offset Register (VTOR).
+   --  VTOR is implemented in Cortex-M0+, Cortex-M4 and above.
+
+   Has_OS_Extensions : constant Boolean := True;
+   --  Set to true if core has armv6-m OS extensions (PendSV, MSP, PSP,
+   --  etc...).
+
+   Is_ARMv6m : constant Boolean := True;
+   --  Set to true if core is an armv6-m (Cortex-M0, Cortex-M0+, Cortex-M1)
+
+   ----------
+   -- CPUS --
+   ----------
+
+   Max_Number_Of_CPUs : constant := 1;
+   --  Maximum number of CPUs
+
+   Multiprocessor : constant Boolean := Max_Number_Of_CPUs /= 1;
+   --  Are we on a multiprocessor board?
+
+end System.BB.Parameters;

--- a/support/bsp_sources/archsupport.py
+++ b/support/bsp_sources/archsupport.py
@@ -5,8 +5,8 @@ from support.files_holder import FilesHolder, FilePair
 
 
 class LdScript(FilePair):
-    def __init__(self, dst, src, loaders):
-        super(LdScript, self).__init__(dst=dst, src=src)
+    def __init__(self, dst, src, loaders, template_config):
+        super(LdScript, self).__init__(dst=dst, src=src, template_config=template_config)
         if loaders is None:
             self._loaders = None
         elif is_string(loaders):
@@ -100,9 +100,9 @@ class ArchSupport(FilesHolder):
 
         if dst is None:
             # not a pair: just copy the script without renaming it
-            obj = LdScript(os.path.basename(script), script, loader)
+            obj = LdScript(os.path.basename(script), script, loader, self._template_config)
         else:
-            obj = LdScript(dst, script, loader)
+            obj = LdScript(dst, script, loader, self._template_config)
 
         assert obj not in self.ld_scripts, \
             "duplicated ld script name %s" % str(obj)


### PR DESCRIPTION
This is a resubmission of #39 with the following updates:
- Eliminated the large number of file variants and replaced them with templated files (using the new template system).
- Bumped copyright years of the STM32F0xx source files to 2020.
- Fixed some issues in the new template system:
  - Fixed template config values not being used when installing linker scripts.
  - ~Fixed case where source files generated from templates do not use the correct line endings on Windows (by default the runtime installer was using CRLF line endings on Windows, but GNAT style rules require LF line endings).~ (this has now been fixed separately in commit 3d1542e)

I've also squashed all changes into a single commit.