### PR TITLE
Customizable runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,98 @@ information, assuming GNAT is installed in ~/install/gnat, run the following:
 ```
 gprbuild -P ~/install/gnat/arm-eabi/lib/gnat/ravenscar-sfp-stm32f4/ravenscar-build.gpr -XBUILD=Debug
 ```
+
+## customizing runtimes
+
+Some targets are configurable and allow certain parts of the runtime to be customized during generation.
+For example, with a custom system clock configuration.
+
+The configuration for such runtimes are defined in a JSON file in the following format:
+
+```json
+{
+    "base_target": "<base target name>",
+    "board_name": "<my board name>",
+    "board_params": {
+        "param1": 123,
+        "param2": "example",
+        "param3": True
+    }
+}
+```
+
+* `base_target` is the name of the target that will be customized. This can be any runtime
+supported by bb-runtimes, but note that not all targets can be customized. Targets that are
+not customizable will ignore the contents of `board_params`.
+
+* `board_name` sets the name of the generated runtime.
+
+* `board_params` sets the board parameters to use when generating the runtime.
+The set of available board parameters depends on the chosen `base_target`. See the following
+sub-sections of this README for a list of available parameters for each target.
+
+All board parameters are optional. Board parameters that are not defined will use their default value.
+Unrecognized board parameters are ignored.
+
+To generate a runtime with the custom configuration, pass the name of the JSON file to build_rts.py:
+
+```
+./build_rts.py --output=temp --build my-board.json ...
+```
+
+**Note:** The file name *must* end in `.json`
+
+The available board parameters for each customizable `base_target` are described in the following sub-sections:
+
+### stm32f0xx board parameters
+
+These are the board parameters for stm32f0xx `base_target`s:
+
+**Note:** The `base_target` is the full STM32 device name, e.g. "stm32f072rb", or "stm32f030r8".
+
+| Parameter          | Type  | Default Value | Description                                      |
+|:------------------:|:-----:|:-------------:|:-------------------------------------------------|
+| `sysclk_frequency` | `int` | 48000000      | Configures the target SYSCLK (and CPU) frequency (in Hz). |
+| `hse_frequency`    | `int` | 8000000       | Specifies the frequency (in Hz) of the board's HSE oscillator. Valid range is 4 MHz - 32 MHz. |
+| `clock_source`     | `str` | "HSE"         | Configures the source oscillator used to generate SYSCLK. Valid values are "HSE", "HSI", and "HSI48". |
+| `hse_bypass`       | `bool` | False        | Enables or disables the HSE bypass (see the STM32F0xx Reference Manual). |
+| `lsi_enabled`      | `bool` | True         | Enables or disables the LSI oscillator at startup. |
+| `apb_prescaler`    | `int`  | 1            | Configures the APB prescaler. Valid values are: 1, 2, 4, 8, 16. |
+
+Here is an example configuration to generate a runtime for the Nucleo-F072RB board from ST (no external HSE oscillator fitted):
+
+```json
+{
+    "base_target": "stm32f072rb",
+    "board_name": "nucleo-f072rb",
+    "board_params": {
+        "sysclk_frequency": 48000000,
+        "clock_source": "HSI"
+    }
+}
+```
+
+### nRF52 board parameters
+
+These are the board parameters for the nrf52832 and nrf52840 `base_target`s:
+
+| Parameter   | Type   | Default Value | Description                                      |
+|:-----------:|:------:|:-------------:|:-------------------------------------------------|
+| `use_hfxo`  | `bool` | False         | Selects whether the high-frequency external oscillator (HFXO) is enabled at startup. When False the internal oscillator is used by default. |
+| `lfclk_src` | `str`  | "Xtal"        | Selects the clock source used for the low-frequency (32 kHz) clock that drives the RTC peripherals. Valid values are: "Xtal", "Rc", and "Synth" |
+| `use_swo_trace` | `bool` | True      | Set to True to configure the SWO trace pins to enable debugging. When False,the SWO pins are not configured. |
+| `use_reset_pin` | `bool` | True      | Set to True to configure pin P0.18 as the reset pin. When False, the reset pin is not configured. |
+| `alarm_rtc_periph` | `str` | "RTC0"  | Selects which RTC peripheral is used to implement the clock for Ravenscar delays (Ada.Real_Time). Valid values are: "RTC0", "RTC1", "RTC2" |
+
+Here is an example configuration to generate a runtime that enables the HFXO at startup, and uses RTC1 for Ravenscar delays:
+
+```json
+{
+    "base_target": "nrf52840",
+    "board_name": "my-board",
+    "board_params": {
+        "use_hfxo": True,
+        "alarm_rtc_periph": "RTC1"
+    }
+}
+```

--- a/arm/nordic/nrf52/nrf52832/setup_board.adb.tmpl
+++ b/arm/nordic/nrf52/nrf52832/setup_board.adb.tmpl
@@ -26,7 +26,7 @@
 ------------------------------------------------------------------------------
 
 --  This file is based on the startup code from the following file in Nordic's
---  nRF5 SDK (version 15.1.0): modules/nrfx/mdk/system_nrf52840.c for errata
+--  nRF5 SDK (version 15.1.0): modules/nrfx/mdk/system_nrf52.c for errata
 --  workarounds and configuration of the SWD pins and reset pin.
 --
 --  This Errata_X functions detect if certain errata are applicable for the
@@ -41,8 +41,8 @@ pragma Suppress (All_Checks);
 with System;
 with System.Machine_Code;    use System.Machine_Code;
 
+with Interfaces;             use Interfaces;
 with Interfaces.NRF52;       use Interfaces.NRF52;
-with Interfaces.NRF52.CCM;   use Interfaces.NRF52.CCM;
 with Interfaces.NRF52.CLOCK; use Interfaces.NRF52.CLOCK;
 with Interfaces.NRF52.FICR;  use Interfaces.NRF52.FICR;
 with Interfaces.NRF52.GPIO;  use Interfaces.NRF52.GPIO;
@@ -56,25 +56,22 @@ procedure Setup_Board is
    --  Board Configuration  --
    ---------------------------
 
-   Use_HFXO : constant Boolean := False;
+   Use_HFXO : constant Boolean := "${NRF52_Use_HFXO}";
    --  Set to True to use the high-frequency external oscillator (HFXO).
    --  When False, the on-chip oscillator is used.
    --  The HFXO can also be turned on and off later by the main program.
 
-   LFCLK_Source : constant LFCLKSRC_SRC_Field := Xtal;
+   LFCLK_Source : constant LFCLKSRC_SRC_Field := "${NRF52_LFCLK_Src}";
    --  Selects the source for the LFCLK.
    --  Xtal selects the external 32.768 kHz crystal (LFXO).
    --  Rc selects the internal 32.768 kHz RC oscillator.
    --  Synth selects the LFCLK synthesized from the 16 MHz HFCLK.
 
-   Use_SWO_Trace : constant Boolean := True;
+   Use_SWO_Trace : constant Boolean := "${NRF52_Use_SWO_Trace}";
    --  Set to True to enable the SWO trace pins.
 
-   Use_Reset_Pin : constant Boolean := True;
+   Use_Reset_Pin : constant Boolean := "${NRF52_Use_Reset_Pin}";
    --  When True, P0.18 will be configured as the reset pin.
-
-   LFRC_Used : constant Boolean := LFCLK_Source = Rc;
-   --  When the LFRC oscillator is not used it is put into ultra-low power mode
 
    --------------------------
    --  Errata Workarounds  --
@@ -85,20 +82,52 @@ procedure Setup_Board is
    --  certain errata are applicable.
 
    Undocumented_Reg_1 : UInt32
-      with Address => System'To_Address (16#1000_0130#);
+      with Address => System'To_Address (16#F000_0FE0#);
 
    Undocumented_Reg_2 : UInt32
+      with Address => System'To_Address (16#F000_0FE4#);
+
+   Undocumented_Reg_3 : UInt32
+      with Address => System'To_Address (16#F000_0FE8#);
+
+   Undocumented_Reg_4 : UInt32
+      with Address => System'To_Address (16#1000_0130#);
+
+   Undocumented_Reg_5 : UInt32
       with Address => System'To_Address (16#1000_0134#);
 
-   --  Undocumented Registers used for the workaround of Erratas 98, 115, 120.
-   Errata_98_Reg : UInt32
-      with Volatile, Address => System'To_Address (16#4000_568C#);
-   Errata_115_Reg_1 : UInt32
+   --  Undocumented registers used for the workaround of erratas 12, 16
+   Errata_12_Reg_1 : UInt32
+      with Volatile, Address => System'To_Address (16#4001_3540#);
+   Errata_12_Reg_2 : UInt32
+      with Volatile, Address => System'To_Address (16#1000_0324#);
+   Errata_16_Reg : UInt32
+      with Volatile, Address => System'To_Address (16#4007_C074#);
+   Errata_31_Reg_1 : UInt32
+      with Volatile, Address => System'To_Address (16#4000_053C#);
+   Errata_31_Reg_2 : UInt32
+      with Volatile, Address => System'To_Address (16#1000_0244#);
+   Errata_37_Reg : UInt32
+      with Volatile, Address => System'To_Address (16#4000_05A0#);
+   Errata_57_Reg_1 : UInt32
+      with Volatile, Address => System'To_Address (16#4000_5610#);
+   Errata_57_Reg_2 : UInt32
+      with Volatile, Address => System'To_Address (16#4000_5688#);
+   Errata_57_Reg_3 : UInt32
+      with Volatile, Address => System'To_Address (16#4000_5618#);
+   Errata_57_Reg_4 : UInt32
+      with Volatile, Address => System'To_Address (16#4000_5614#);
+   Errata_108_Reg_1 : UInt32
       with Volatile, Address => System'To_Address (16#4000_0EE4#);
-   Errata_115_Reg_2 : UInt32
+   Errata_108_Reg_2 : UInt32
       with Volatile, Address => System'To_Address (16#1000_0258#);
-   Errata_120_Reg : UInt32
-      with Volatile, Address => System'To_Address (16#4002_9640#);
+   Errata_182_Reg : UInt32
+      with Volatile, Address => System'To_Address (16#4000_173C#);
+
+   CoreDebug_DEMCR : UInt32
+      with Volatile, Address => System'To_Address (16#E000_EDFC#);
+
+   DEMCR_TRCENA_Mask : constant UInt32 := 16#0100_0000#;
 
    --  The POWER.RESETREAS register.
    --  We define this here instead of including Interfaces.POWER as a
@@ -108,35 +137,71 @@ procedure Setup_Board is
       with Volatile, Address => System'To_Address (16#4000_0400#);
 
    --  The following functions detect if different errata are applicable on
-   --  the specific MCU revision. For example, Errata_36 checks if a errata #36
-   --  is applicable ("CLOCK: Some registers are not reset when expected").
+   --  the specific MCU revision. For example, Errata_12 checks if a errata #12
+   --  is applicable ("COMP: Reference ladder not correctly calibrated").
+
+   function Errata_12 return Boolean is
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
+     with Inline_Always;
+
+   function Errata_16 return Boolean is
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
+     with Inline_Always;
+
+   function Errata_31 return Boolean is
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
+     with Inline_Always;
+
+   function Errata_32 return Boolean is
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
+     with Inline_Always;
 
    function Errata_36 return Boolean is
-      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
+     with Inline_Always;
+
+   function Errata_37 return Boolean is
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
+     with Inline_Always;
+
+   function Errata_57 return Boolean is
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
      with Inline_Always;
 
    function Errata_66 return Boolean is
-      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) = 16#50#))
      with Inline_Always;
 
-   function Errata_98 return Boolean is
-      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
-     with Inline_Always;
-
-   function Errata_103 return Boolean is
-      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
-     with Inline_Always;
-
-   function Errata_115 return Boolean is
-      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
-     with Inline_Always;
-
-   function Errata_120 return Boolean is
-      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
+   function Errata_108 return Boolean is
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
      with Inline_Always;
 
    function Errata_136 return Boolean is
-      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
+      (((Undocumented_Reg_1 and 16#FF#) = 6)
+       and ((Undocumented_Reg_2 and 16#F#) = 0)
+       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
+     with Inline_Always;
+
+   function Errata_182 return Boolean is
+      (Undocumented_Reg_4 = 6 and Undocumented_Reg_5 = 6)
      with Inline_Always;
 
    procedure NVIC_SystemReset;
@@ -169,8 +234,9 @@ begin
 
    --  Enable SWO trace pins
    if Use_SWO_Trace then
+      CoreDebug_DEMCR := CoreDebug_DEMCR or DEMCR_TRCENA_Mask;
       CLOCK_Periph.TRACECONFIG.TRACEMUX := Serial;
-      P1_Periph.PIN_CNF (0) := PIN_CNF_Register'
+      P0_Periph.PIN_CNF (18) := PIN_CNF_Register'
          (DIR            => Output,
           INPUT          => Connect,
           PULL           => Disabled,
@@ -181,12 +247,49 @@ begin
           Reserved_18_31 => 0);
    end if;
 
+   --  Workaround for Errata 12 "COMP: Reference ladder not correctly
+   --  calibrated"
+   if Errata_12 then
+      Errata_12_Reg_1 := Shift_Right (Errata_12_Reg_2 and 16#1F00#, 8);
+   end if;
+
+   --  Workaround for Errata 16 "System: RAM may be corrupt on wakeup from
+   --  CPU IDLE"
+   if Errata_16 then
+      Errata_16_Reg := 3131961357;
+   end if;
+
+   --  Workaround for Errata 31 "CLOCK: Calibration values are not correctly
+   --  loaded from FICR at reset"
+   if Errata_31 then
+      Errata_31_Reg_1 := Shift_Right (Errata_31_Reg_2 and 16#E000#, 13);
+   end if;
+
+   --  Workaround for Errata 32 "DIF: Debug session automatically enables
+   --  TracePort pins"
+   if Errata_32 then
+      CoreDebug_DEMCR := CoreDebug_DEMCR and (not DEMCR_TRCENA_Mask);
+   end if;
+
    --  Workaround for Errata 36 "CLOCK: Some registers are not reset when
-   --  expected".
+   --  expected"
    if Errata_36 then
       CLOCK_Periph.EVENTS_DONE := (EVENTS_DONE => 0, others => <>);
       CLOCK_Periph.EVENTS_CTTO := (EVENTS_CTTO => 0, others => <>);
-      CLOCK_Periph.CTIV.CTIV   := 0;
+      CLOCK_Periph.CTIV        := (CTIV => 0, Reserved_7_31 => 0);
+   end if;
+
+   --  Workaround for Errata 37 "RADIO: Encryption engine is slow by default"
+   if Errata_37 then
+      Errata_37_Reg := 3;
+   end if;
+
+   --  Workaround for Errata 57 "NFCT: NFC Modulation amplitude"
+   if Errata_57 then
+      Errata_57_Reg_1 := 16#0000_0005#;
+      Errata_57_Reg_2 := 16#0000_0001#;
+      Errata_57_Reg_3 := 16#0000_0000#;
+      Errata_57_Reg_4 := 16#0000_003F#;
    end if;
 
    --  Workaround for Errata 66 "TEMP: Linearity specification not met with
@@ -211,26 +314,10 @@ begin
       TEMP_Periph.T4.T4 := FICR_Periph.TEMP.T4.T;
    end if;
 
-   --  Workaround for Errata 98 "NFCT: Not able to communicate with the peer"
-   if Errata_98 then
-      Errata_98_Reg := 16#0003_8148#;
-   end if;
-
-   --  Workaround for Errata 103 "CCM: Wrong reset value of CCM MAXPACKETSIZE"
-   if Errata_103 then
-      CCM_Periph.MAXPACKETSIZE.MAXPACKETSIZE := 16#FB#;
-   end if;
-
-   --  Workaround for Errata 115 "RAM: RAM content cannot be trusted upon
+   --  Workaround for Errata 108 "RAM: RAM content cannot be trusted upon
    --  waking up from System ON Idle or System OFF mode"
-   if Errata_115 then
-      Errata_115_Reg_1 := ((Errata_115_Reg_1 and 16#FFFF_FFF0#)
-                           or (Errata_115_Reg_2 and 16#0000_000F#));
-   end if;
-
-   --  Workaround for Errata 120 "QSPI: Data read or written is corrupted"
-   if Errata_120 then
-      Errata_120_Reg := 16#200#;
+   if Errata_108 then
+      Errata_108_Reg_1 := Errata_108_Reg_2 and 16#0000_004F#;
    end if;
 
    --  Workaround for Errata 136 "System: Bits in RESETREAS are set when they
@@ -240,6 +327,12 @@ begin
       if (POWER_RESETREAS and 16#0000_0001#) /= 0 then
          POWER_RESETREAS := 16#FFFF_FFFE#;
       end if;
+   end if;
+
+   --  Workaround for Errata 182 "RADIO: Fixes for anomalies #102, #106, and
+   --  #107 do not take effect"
+   if Errata_182 then
+      Errata_182_Reg := Errata_182_Reg or 16#200#;
    end if;
 
    if Use_Reset_Pin then
@@ -255,8 +348,7 @@ begin
          end loop;
 
          UICR_Periph.PSELRESET (0) := PSELRESET_Register'
-            (PIN           => 18,
-             PORT          => 0,
+            (PIN           => 21,
              Reserved_6_30 => 0,
              CONNECT       => Connected);
          loop
@@ -264,8 +356,7 @@ begin
          end loop;
 
          UICR_Periph.PSELRESET (1) := PSELRESET_Register'
-            (PIN           => 18,
-             PORT          => 0,
+            (PIN           => 21,
              Reserved_6_30 => 0,
              CONNECT       => Connected);
          loop
@@ -297,16 +388,9 @@ begin
       EXTERNAL       => Disabled,
       Reserved_18_31 => 0);
 
-   --  If the internal RC oscillator is not used as the LFCLK source, then
-   --  put it into ultra-low power (ULP) mode to save some power.
-   if not LFRC_Used then
-      CLOCK_Periph.LFRCMODE.MODE := Ulp;
-   end if;
-
    --  Optionally enable the external HFXO.
    --  If HFXO is disabled, then the HFCLK will use the internal HF oscillator
    if Use_HFXO then
-      CLOCK_Periph.TASKS_HFCLKSTART := (TASKS_HFCLKSTART => 1,
-                                        others           => <>);
+      CLOCK_Periph.TASKS_HFCLKSTART := (TASKS_HFCLKSTART => 1, others => <>);
    end if;
 end Setup_Board;

--- a/arm/nordic/nrf52/nrf52840/setup_board.adb.tmpl
+++ b/arm/nordic/nrf52/nrf52840/setup_board.adb.tmpl
@@ -26,7 +26,7 @@
 ------------------------------------------------------------------------------
 
 --  This file is based on the startup code from the following file in Nordic's
---  nRF5 SDK (version 15.1.0): modules/nrfx/mdk/system_nrf52.c for errata
+--  nRF5 SDK (version 15.1.0): modules/nrfx/mdk/system_nrf52840.c for errata
 --  workarounds and configuration of the SWD pins and reset pin.
 --
 --  This Errata_X functions detect if certain errata are applicable for the
@@ -41,8 +41,8 @@ pragma Suppress (All_Checks);
 with System;
 with System.Machine_Code;    use System.Machine_Code;
 
-with Interfaces;             use Interfaces;
 with Interfaces.NRF52;       use Interfaces.NRF52;
+with Interfaces.NRF52.CCM;   use Interfaces.NRF52.CCM;
 with Interfaces.NRF52.CLOCK; use Interfaces.NRF52.CLOCK;
 with Interfaces.NRF52.FICR;  use Interfaces.NRF52.FICR;
 with Interfaces.NRF52.GPIO;  use Interfaces.NRF52.GPIO;
@@ -56,22 +56,25 @@ procedure Setup_Board is
    --  Board Configuration  --
    ---------------------------
 
-   Use_HFXO : constant Boolean := False;
+   Use_HFXO : constant Boolean := "${NRF52_Use_HFXO}";
    --  Set to True to use the high-frequency external oscillator (HFXO).
    --  When False, the on-chip oscillator is used.
    --  The HFXO can also be turned on and off later by the main program.
 
-   LFCLK_Source : constant LFCLKSRC_SRC_Field := Xtal;
+   LFCLK_Source : constant LFCLKSRC_SRC_Field := "${NRF52_LFCLK_Src}";
    --  Selects the source for the LFCLK.
    --  Xtal selects the external 32.768 kHz crystal (LFXO).
    --  Rc selects the internal 32.768 kHz RC oscillator.
    --  Synth selects the LFCLK synthesized from the 16 MHz HFCLK.
 
-   Use_SWO_Trace : constant Boolean := True;
+   Use_SWO_Trace : constant Boolean := "${NRF52_Use_SWO_Trace}";
    --  Set to True to enable the SWO trace pins.
 
-   Use_Reset_Pin : constant Boolean := True;
+   Use_Reset_Pin : constant Boolean := "${NRF52_Use_Reset_Pin}";
    --  When True, P0.18 will be configured as the reset pin.
+
+   LFRC_Used : constant Boolean := LFCLK_Source = Rc;
+   --  When the LFRC oscillator is not used it is put into ultra-low power mode
 
    --------------------------
    --  Errata Workarounds  --
@@ -82,52 +85,20 @@ procedure Setup_Board is
    --  certain errata are applicable.
 
    Undocumented_Reg_1 : UInt32
-      with Address => System'To_Address (16#F000_0FE0#);
-
-   Undocumented_Reg_2 : UInt32
-      with Address => System'To_Address (16#F000_0FE4#);
-
-   Undocumented_Reg_3 : UInt32
-      with Address => System'To_Address (16#F000_0FE8#);
-
-   Undocumented_Reg_4 : UInt32
       with Address => System'To_Address (16#1000_0130#);
 
-   Undocumented_Reg_5 : UInt32
+   Undocumented_Reg_2 : UInt32
       with Address => System'To_Address (16#1000_0134#);
 
-   --  Undocumented registers used for the workaround of erratas 12, 16
-   Errata_12_Reg_1 : UInt32
-      with Volatile, Address => System'To_Address (16#4001_3540#);
-   Errata_12_Reg_2 : UInt32
-      with Volatile, Address => System'To_Address (16#1000_0324#);
-   Errata_16_Reg : UInt32
-      with Volatile, Address => System'To_Address (16#4007_C074#);
-   Errata_31_Reg_1 : UInt32
-      with Volatile, Address => System'To_Address (16#4000_053C#);
-   Errata_31_Reg_2 : UInt32
-      with Volatile, Address => System'To_Address (16#1000_0244#);
-   Errata_37_Reg : UInt32
-      with Volatile, Address => System'To_Address (16#4000_05A0#);
-   Errata_57_Reg_1 : UInt32
-      with Volatile, Address => System'To_Address (16#4000_5610#);
-   Errata_57_Reg_2 : UInt32
-      with Volatile, Address => System'To_Address (16#4000_5688#);
-   Errata_57_Reg_3 : UInt32
-      with Volatile, Address => System'To_Address (16#4000_5618#);
-   Errata_57_Reg_4 : UInt32
-      with Volatile, Address => System'To_Address (16#4000_5614#);
-   Errata_108_Reg_1 : UInt32
+   --  Undocumented Registers used for the workaround of Erratas 98, 115, 120.
+   Errata_98_Reg : UInt32
+      with Volatile, Address => System'To_Address (16#4000_568C#);
+   Errata_115_Reg_1 : UInt32
       with Volatile, Address => System'To_Address (16#4000_0EE4#);
-   Errata_108_Reg_2 : UInt32
+   Errata_115_Reg_2 : UInt32
       with Volatile, Address => System'To_Address (16#1000_0258#);
-   Errata_182_Reg : UInt32
-      with Volatile, Address => System'To_Address (16#4000_173C#);
-
-   CoreDebug_DEMCR : UInt32
-      with Volatile, Address => System'To_Address (16#E000_EDFC#);
-
-   DEMCR_TRCENA_Mask : constant UInt32 := 16#0100_0000#;
+   Errata_120_Reg : UInt32
+      with Volatile, Address => System'To_Address (16#4002_9640#);
 
    --  The POWER.RESETREAS register.
    --  We define this here instead of including Interfaces.POWER as a
@@ -137,71 +108,35 @@ procedure Setup_Board is
       with Volatile, Address => System'To_Address (16#4000_0400#);
 
    --  The following functions detect if different errata are applicable on
-   --  the specific MCU revision. For example, Errata_12 checks if a errata #12
-   --  is applicable ("COMP: Reference ladder not correctly calibrated").
-
-   function Errata_12 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
-     with Inline_Always;
-
-   function Errata_16 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
-     with Inline_Always;
-
-   function Errata_31 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
-     with Inline_Always;
-
-   function Errata_32 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
-     with Inline_Always;
+   --  the specific MCU revision. For example, Errata_36 checks if a errata #36
+   --  is applicable ("CLOCK: Some registers are not reset when expected").
 
    function Errata_36 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
-     with Inline_Always;
-
-   function Errata_37 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
-     with Inline_Always;
-
-   function Errata_57 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) = 16#30#))
+      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
      with Inline_Always;
 
    function Errata_66 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) = 16#50#))
+      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
      with Inline_Always;
 
-   function Errata_108 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
+   function Errata_98 return Boolean is
+      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
+     with Inline_Always;
+
+   function Errata_103 return Boolean is
+      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
+     with Inline_Always;
+
+   function Errata_115 return Boolean is
+      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
+     with Inline_Always;
+
+   function Errata_120 return Boolean is
+      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
      with Inline_Always;
 
    function Errata_136 return Boolean is
-      (((Undocumented_Reg_1 and 16#FF#) = 6)
-       and ((Undocumented_Reg_2 and 16#F#) = 0)
-       and ((Undocumented_Reg_3 and 16#F0#) in 16#30# | 16#40# | 16#50#))
-     with Inline_Always;
-
-   function Errata_182 return Boolean is
-      (Undocumented_Reg_4 = 6 and Undocumented_Reg_5 = 6)
+      (Undocumented_Reg_1 = 8 and Undocumented_Reg_2 = 0)
      with Inline_Always;
 
    procedure NVIC_SystemReset;
@@ -234,9 +169,8 @@ begin
 
    --  Enable SWO trace pins
    if Use_SWO_Trace then
-      CoreDebug_DEMCR := CoreDebug_DEMCR or DEMCR_TRCENA_Mask;
       CLOCK_Periph.TRACECONFIG.TRACEMUX := Serial;
-      P0_Periph.PIN_CNF (18) := PIN_CNF_Register'
+      P1_Periph.PIN_CNF (0) := PIN_CNF_Register'
          (DIR            => Output,
           INPUT          => Connect,
           PULL           => Disabled,
@@ -247,49 +181,12 @@ begin
           Reserved_18_31 => 0);
    end if;
 
-   --  Workaround for Errata 12 "COMP: Reference ladder not correctly
-   --  calibrated"
-   if Errata_12 then
-      Errata_12_Reg_1 := Shift_Right (Errata_12_Reg_2 and 16#1F00#, 8);
-   end if;
-
-   --  Workaround for Errata 16 "System: RAM may be corrupt on wakeup from
-   --  CPU IDLE"
-   if Errata_16 then
-      Errata_16_Reg := 3131961357;
-   end if;
-
-   --  Workaround for Errata 31 "CLOCK: Calibration values are not correctly
-   --  loaded from FICR at reset"
-   if Errata_31 then
-      Errata_31_Reg_1 := Shift_Right (Errata_31_Reg_2 and 16#E000#, 13);
-   end if;
-
-   --  Workaround for Errata 32 "DIF: Debug session automatically enables
-   --  TracePort pins"
-   if Errata_32 then
-      CoreDebug_DEMCR := CoreDebug_DEMCR and (not DEMCR_TRCENA_Mask);
-   end if;
-
    --  Workaround for Errata 36 "CLOCK: Some registers are not reset when
-   --  expected"
+   --  expected".
    if Errata_36 then
       CLOCK_Periph.EVENTS_DONE := (EVENTS_DONE => 0, others => <>);
       CLOCK_Periph.EVENTS_CTTO := (EVENTS_CTTO => 0, others => <>);
-      CLOCK_Periph.CTIV        := (CTIV => 0, Reserved_7_31 => 0);
-   end if;
-
-   --  Workaround for Errata 37 "RADIO: Encryption engine is slow by default"
-   if Errata_37 then
-      Errata_37_Reg := 3;
-   end if;
-
-   --  Workaround for Errata 57 "NFCT: NFC Modulation amplitude"
-   if Errata_57 then
-      Errata_57_Reg_1 := 16#0000_0005#;
-      Errata_57_Reg_2 := 16#0000_0001#;
-      Errata_57_Reg_3 := 16#0000_0000#;
-      Errata_57_Reg_4 := 16#0000_003F#;
+      CLOCK_Periph.CTIV.CTIV   := 0;
    end if;
 
    --  Workaround for Errata 66 "TEMP: Linearity specification not met with
@@ -314,10 +211,26 @@ begin
       TEMP_Periph.T4.T4 := FICR_Periph.TEMP.T4.T;
    end if;
 
-   --  Workaround for Errata 108 "RAM: RAM content cannot be trusted upon
+   --  Workaround for Errata 98 "NFCT: Not able to communicate with the peer"
+   if Errata_98 then
+      Errata_98_Reg := 16#0003_8148#;
+   end if;
+
+   --  Workaround for Errata 103 "CCM: Wrong reset value of CCM MAXPACKETSIZE"
+   if Errata_103 then
+      CCM_Periph.MAXPACKETSIZE.MAXPACKETSIZE := 16#FB#;
+   end if;
+
+   --  Workaround for Errata 115 "RAM: RAM content cannot be trusted upon
    --  waking up from System ON Idle or System OFF mode"
-   if Errata_108 then
-      Errata_108_Reg_1 := Errata_108_Reg_2 and 16#0000_004F#;
+   if Errata_115 then
+      Errata_115_Reg_1 := ((Errata_115_Reg_1 and 16#FFFF_FFF0#)
+                           or (Errata_115_Reg_2 and 16#0000_000F#));
+   end if;
+
+   --  Workaround for Errata 120 "QSPI: Data read or written is corrupted"
+   if Errata_120 then
+      Errata_120_Reg := 16#200#;
    end if;
 
    --  Workaround for Errata 136 "System: Bits in RESETREAS are set when they
@@ -327,12 +240,6 @@ begin
       if (POWER_RESETREAS and 16#0000_0001#) /= 0 then
          POWER_RESETREAS := 16#FFFF_FFFE#;
       end if;
-   end if;
-
-   --  Workaround for Errata 182 "RADIO: Fixes for anomalies #102, #106, and
-   --  #107 do not take effect"
-   if Errata_182 then
-      Errata_182_Reg := Errata_182_Reg or 16#200#;
    end if;
 
    if Use_Reset_Pin then
@@ -348,7 +255,8 @@ begin
          end loop;
 
          UICR_Periph.PSELRESET (0) := PSELRESET_Register'
-            (PIN           => 21,
+            (PIN           => 18,
+             PORT          => 0,
              Reserved_6_30 => 0,
              CONNECT       => Connected);
          loop
@@ -356,7 +264,8 @@ begin
          end loop;
 
          UICR_Periph.PSELRESET (1) := PSELRESET_Register'
-            (PIN           => 21,
+            (PIN           => 18,
+             PORT          => 0,
              Reserved_6_30 => 0,
              CONNECT       => Connected);
          loop
@@ -388,9 +297,16 @@ begin
       EXTERNAL       => Disabled,
       Reserved_18_31 => 0);
 
+   --  If the internal RC oscillator is not used as the LFCLK source, then
+   --  put it into ultra-low power (ULP) mode to save some power.
+   if not LFRC_Used then
+      CLOCK_Periph.LFRCMODE.MODE := Ulp;
+   end if;
+
    --  Optionally enable the external HFXO.
    --  If HFXO is disabled, then the HFCLK will use the internal HF oscillator
    if Use_HFXO then
-      CLOCK_Periph.TASKS_HFCLKSTART := (TASKS_HFCLKSTART => 1, others => <>);
+      CLOCK_Periph.TASKS_HFCLKSTART := (TASKS_HFCLKSTART => 1,
+                                        others           => <>);
    end if;
 end Setup_Board;

--- a/src/s-bbbosu__nrf52.adb.tmpl
+++ b/src/s-bbbosu__nrf52.adb.tmpl
@@ -56,14 +56,14 @@ package body System.BB.Board_Support is
    pragma Volatile (Alarm_Time);
    pragma Export (C, Alarm_Time, "__gnat_alarm_time");
 
-   Alarm_Interrupt_ID : constant Interrupt_ID := 11; --  RTC0 IRQ
+   Alarm_Interrupt_ID : constant Interrupt_ID := "${NRF52_Alarm_Interrupt_ID}";
 
    -------------------
-   -- RTC0 Handling --
+   -- RTC Handling --
    -------------------
 
-   --  RTC0 is used as the clock source, which we use to implement
-   --  "tick-less" alarm handling.
+   --  An RTC peripheral is used as the clock source, which we use to
+   --  implement "tick-less" alarm handling.
    --
    --  The RTC is a 24-bit timer running at 32.768 kHz, resulting in a period
    --  of 512 seconds (2**24 / 32_768).
@@ -71,12 +71,14 @@ package body System.BB.Board_Support is
    --  We use the COMPARE feature of the RTC to provide accurate alarms.
    --  We achieve this by updating CC[0] each time Set_Alarm is called so
    --  that the alarm is triggered exactly at the alarm time. This results in
-   --  an alarm accuracy of 30.518 µs.
+   --  an alarm accuracy of 30.518 us.
    --
    --  Note that the underlying 24-bit RTC runs at a frequency of 32.768 kHz,
    --  but Timer_Interval is scaled up that, at 65.536 kHz ticks (or higher,
    --  depending on RTC_Tick_Scaling_Factor) to ensure that
    --  Ada.Real_Time.Time_Unit meets the requirements in Ada RM D.8/30
+
+   Alarm_RTC : RTC_Peripheral renames "${NRF52_Alarm_RTC_Periph}"_Periph;
 
    ----------------------------------------------
    -- New Vectored Interrupt Controller (NVIC) --
@@ -138,12 +140,12 @@ package body System.BB.Board_Support is
 
       -- Timer --
 
-      --  The 32.768 kHz RTC0 peripheral is used as the clock source on this
+      --  The 32.768 kHz RTC peripheral is used as the clock source on this
       --  board. This is used instead of the SysTick timer because the "wfi"
       --  instruction (used for entering the CPU sleep mode to save power)
       --  powers down the entire CPU, *including* the SysTick.
       --  Since we still want to use "wfi" to save power whilst keeping task
-      --  delays alive, we instead use the RTC0 peripheral.
+      --  delays alive, we instead use the RTC peripheral.
 
       --  Start LFCLK
       --  We assume that the LFCLK source (Xtal, Rc, or Synth) has already been
@@ -160,22 +162,22 @@ package body System.BB.Board_Support is
                                            others              => <>);
 
       --  Ensure RTC is stopped.
-      RTC0_Periph.TASKS_STOP := (TASKS_STOP => 1, others => <>);
+      Alarm_RTC.TASKS_STOP := (TASKS_STOP => 1, others => <>);
 
       --  Set to 0 before setting TASKS_CLEAR to prevent triggering a COMPARE
       --  event.
-      RTC0_Periph.CC (0).COMPARE      := 0;
+      Alarm_RTC.CC (0).COMPARE      := 0;
 
       --  Clear RTC
-      RTC0_Periph.TASKS_CLEAR := (TASKS_CLEAR => 1, others => <>);
+      Alarm_RTC.TASKS_CLEAR := (TASKS_CLEAR => 1, others => <>);
 
       --  Run at 32.768 kHz
-      RTC0_Periph.PRESCALER.PRESCALER := 0;
+      Alarm_RTC.PRESCALER.PRESCALER := 0;
 
       --  Enable CC[0] interrupt only; TICK and OVRFLW aren't needed.
-      RTC0_Periph.INTENSET.TICK       := Intenset_Tick_Field_Reset;
-      RTC0_Periph.INTENSET.OVRFLW     := Intenset_Ovrflw_Field_Reset;
-      RTC0_Periph.INTENSET.COMPARE    := (As_Array => False, --  Use COMPARE0
+      Alarm_RTC.INTENSET.TICK       := Intenset_Tick_Field_Reset;
+      Alarm_RTC.INTENSET.OVRFLW     := Intenset_Ovrflw_Field_Reset;
+      Alarm_RTC.INTENSET.COMPARE    := (As_Array => False, --  Use COMPARE0
                                           Val      => 2#0001#);
 
       Time.Set_Alarm (Max_Timer_Interval);
@@ -224,7 +226,7 @@ package body System.BB.Board_Support is
          --  Double the value of the COUNTER register since the RTC runs at
          --  32.768 kHz, but our Timer_Interval values are in scaled up units
          --  (e.g. 65.536 kHz if RTC_Tick_Scaling_Factor is 2)
-         Res := Timer_Interval (RTC0_Periph.COUNTER.COUNTER);
+         Res := Timer_Interval (Alarm_RTC.COUNTER.COUNTER);
          Res := Res * BBOPA.RTC_Tick_Scaling_Factor;
 
          --  Restore interrupt mask
@@ -245,7 +247,7 @@ package body System.BB.Board_Support is
          --  Only clear the COMPARE event; don't clear OVRFLW here since we
          --  read (and clear) that event in Read_Clock to return the correct
          --  time when an overflow occurs.
-         RTC0_Periph.EVENTS_COMPARE (0) := (EVENTS_COMPARE => 0, others => <>);
+         Alarm_RTC.EVENTS_COMPARE (0) := (EVENTS_COMPARE => 0, others => <>);
       end Clear_Alarm_Interrupt;
 
       ---------------
@@ -273,9 +275,9 @@ package body System.BB.Board_Support is
          RTC_Ticks := UInt24'Max (RTC_Ticks, 2);
 
          --  Set an interrupt to trigger after the requested number of ticks.
-         RTC_Counter                := RTC0_Periph.COUNTER.COUNTER;
+         RTC_Counter                := Alarm_RTC.COUNTER.COUNTER;
          CC0_Value                  := RTC_Counter + RTC_Ticks;
-         RTC0_Periph.CC (0).COMPARE := CC0_Value;
+         Alarm_RTC.CC (0).COMPARE := CC0_Value;
 
          --  Note that the RTC might have ticked between reading COUNTER and
          --  setting CC[0], which may break the guarantee that CC[0] is always
@@ -288,7 +290,7 @@ package body System.BB.Board_Support is
          --  This might result in an extra unecessary interrupt just before
          --  the alarm time, but ensures the alarm time is not missed.
 
-         RTC_Counter           := RTC0_Periph.COUNTER.COUNTER;
+         RTC_Counter           := Alarm_RTC.COUNTER.COUNTER;
          RTC_Ticks_Until_Alarm := CC0_Value - RTC_Counter;
 
          if RTC_Ticks_Until_Alarm < 2
@@ -296,7 +298,7 @@ package body System.BB.Board_Support is
             or RTC_Ticks_Until_Alarm > RTC_Ticks
          then
             CC0_Value                  := RTC_Counter + RTC_Ticks;
-            RTC0_Periph.CC (0).COMPARE := CC0_Value;
+            Alarm_RTC.CC (0).COMPARE := CC0_Value;
 
             Trigger_Interrupt (Alarm_Interrupt_ID);
          end if;
@@ -318,7 +320,7 @@ package body System.BB.Board_Support is
          Time.Clear_Alarm_Interrupt;
 
          --  Now that the interrupt handler is attached, we can start the timer
-         RTC0_Periph.TASKS_START := (TASKS_START => 1, others => <>);
+         Alarm_RTC.TASKS_START := (TASKS_START => 1, others => <>);
       end Install_Alarm_Handler;
    end Time;
 

--- a/support/files_holder.py
+++ b/support/files_holder.py
@@ -189,7 +189,17 @@ class FilesHolder(object):
          SRC is the full name of the file to copy"""
         base = os.path.basename(src)
         # A file could have `.` in its name. (eg: pikeos4.2-cert-app.c)
-        _, ext = base.rsplit('.', 1)
+        #
+        # Template files have a .tmpl extension, which needs to be kept.
+        # Example:
+        # s-textio__myboard.adb.tmpl should aliased as s-myboard.adb.tmpl
+        # The .tmpl extension is kept for now as it is removed later in
+        # the installation process.
+        if base.endswith('.tmpl'):
+            print(base)
+            _, ext, _ = base.rsplit('.', 2)
+        else:
+            _, ext = base.rsplit('.', 1)
         # Check if the basename of the source file contains two consecutive
         # underscores. This is by naming convention a file variant whose
         # variant part needs to be removed before installation.


### PR DESCRIPTION
### Summary
This adds a new mechanism to allow generated runtimes to be customized with user-defined board parameters defined in JSON files. For example, to change the clock speed of the generated runtime.

### Rationale
The purpose of this work is to make it easier for users to adapt runtimes to different boards without needing to manually edit the generated runtime sources (which can be complicated and requires knowledge of how the runtime sources are organised). 

With this new feature, the user can define a custom JSON file that contains various configuration values for a specific target. This JSON file is then used by the Python scripts use to customize the generate runtime. 

For example, the STM32F0xx runtime configures a 8 MHz HSE by default. If a user has a project that uses a 16 MHz HSE oscillator on their board, they can now easily generate a suitable runtime by creating the following JSON file instead of modifying runtime sources:
```json
{
    "base_target": "stm32f072rb",
    "board_name": "my-board",
    "board_params": {
        "sysclk_frequency": 48000000,
        "hse_frequency": 16000000,
        "clock_source": "HSE"
    }
}
```

and then pass it to build_rts.py:
```
./build_rts.py --output=/path/to/gnat --build my-board.json
```

which will generate then following runtimes that will configure the system clocks to use a 16 MHz HSE:
* ravenscar-full-my-board
* ravenscar-sfp-my-board
* zfp-my-board

### Implementation
When a JSON file is specified on the command line to build_rts.py, the contents of the file are loaded and passed to the Python class that configures the runtime sources for the specific target. The Python code can then use the board parameters, along with the new template system, to customize the generated runtime. 

For example, the `Stm32F0` class in `cortexm.py` now calculates the PLL and system clock parameters based on the configuration loaded from the JSON file. If no JSON file was given, then sensible default values are used instead.

### Supported targets
For now, I've only updated the stm32f0xx and nRF52 runtimes to make use of this feature. The README.md has been updated to document which board parameters can be configured.