### PR TITLE
U423-022: MMU configuration for zynqmp

### DIFF
--- a/aarch64/__init__.py
+++ b/aarch64/__init__.py
@@ -115,7 +115,9 @@ class ZynqMP(Aarch64Target):
             'src/trap_dump__aarch64.ads',
             'src/trap_dump__aarch64.adb',
             'src/s-textio__zynqmp.adb',
-            'src/s-macres__zynqmp.adb')
+            'src/s-macres__zynqmp.adb',
+            'src/s-mmu__zynqmp.ads',
+            'src/s-mmu__zynqmp.adb')
         self.add_gnarl_sources(
             'src/a-intnam__zynqmp.ads',
             'src/s-bbbosu__armv8a.adb',

--- a/aarch64/zynqmp/common.ld
+++ b/aarch64/zynqmp/common.ld
@@ -98,7 +98,21 @@ SECTIONS
   .eh_frame         : { KEEP (*(.eh_frame)) } > REGION_CODE
   .gcc_except_table : { *(.gcc_except_table .gcc_except_table.*) } > REGION_CODE
 
-  . = ALIGN(0x10);
+  . = ALIGN(0x1000);
+
+  __region_data_start = .;
+
+  .mmu_ram_table_2 : ALIGN(0x1000)
+  {
+      __mmu_ram_table_2 = .;
+      . = . + 2 * 0x1000;
+  } > REGION_DATA
+
+  .mmu_ram_table_3 : ALIGN(0x1000)
+  {
+      __mmu_ram_table_3 = .;
+      . = . + 1024 * 0x1000;
+  } > REGION_DATA
 
   __data_load = .;
   .data : AT (__data_load)

--- a/aarch64/zynqmp/start.S
+++ b/aarch64/zynqmp/start.S
@@ -261,7 +261,12 @@ __start_el1:
         cmp     x0, #1
         beq     1f
         bl      __configure_mmu
+
 1:
+        # Initialize MMU tables
+        bl      __initialize_mmu
+        tlbi    vmalle1
+
         # CPU 0 starts master, the other are slave cpus
         mrs     x7, mpidr_el1
         and     x7, x7, #3

--- a/src/s-mmu__zynqmp.adb
+++ b/src/s-mmu__zynqmp.adb
@@ -1,0 +1,267 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--                            S Y S T E M . M M U                           --
+--                                                                          --
+--                                 B o d y                                  --
+--                                                                          --
+--                         Copyright (C) 2021, AdaCore                      --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with System.Machine_Code;
+with Interfaces;
+
+package body System.MMU is
+
+   Set_NX : constant Boolean := True;
+   Set_RO : constant Boolean := True;
+
+   type Level_2_Output_Address is mod 2 ** 27;
+
+   type Level_2_Table_Address is mod 2 ** 36;
+
+   type Level_3_Output_Address is mod 2 ** 36;
+
+   type Attribute_Index is mod 2 ** 3;
+
+   type Access_Permission is (Read_Write_EL1,
+                              Read_Write_EL0,
+                              Read_Only_EL1,
+                              Read_Only_EL0) with
+     Size => 2;
+
+   for Access_Permission use (Read_Write_EL1 => 0,
+                              Read_Write_EL0 => 1,
+                              Read_Only_EL1  => 2,
+                              Read_Only_EL0  => 3);
+
+   type Shareability is (Non_Shareable,
+                         Unpredictable,
+                         Outer_Shareable,
+                         Inner_Shareable) with
+      Size => 2;
+
+   for Shareability use (Non_Shareable   => 0,
+                         Unpredictable   => 1,
+                         Outer_Shareable => 2,
+                         Inner_Shareable => 3);
+
+   type Descriptor_Type is (Block, Table) with
+     Size => 1;
+
+   for Descriptor_Type use (Block => 0, Table => 1);
+
+   type Page_Bit is (Reserved, Page) with
+     Size => 1;
+
+   for Page_Bit use (Reserved => 0, Page => 1);
+
+   type Level_2_Descriptor (Valid  : Boolean         := False;
+                            D_Type : Descriptor_Type := Block) is record
+      case Valid is
+         when True =>
+            case D_Type is
+               when Block =>
+                  Attr_Index    : Attribute_Index;
+                  Non_Secure    : Boolean;
+                  Data_Access   : Access_Permission;
+                  Share         : Shareability;
+                  Access_Flag   : Boolean;
+                  Non_Global    : Boolean;
+                  Block_Address : Level_2_Output_Address;
+                  Contiguous    : Boolean;
+                  PXN_Block     : Boolean;
+                  XN_Block      : Boolean;
+               when Table =>
+                  Table_Address     : Level_2_Table_Address;
+                  PXN_Table         : Boolean;
+                  XN_Table          : Boolean;
+                  Data_Access_Table : Access_Permission;
+                  Non_Secure_Table  : Boolean;
+            end case;
+         when False =>
+            null;
+      end case;
+   end record with
+     Size => 64;
+
+   for Level_2_Descriptor use record
+      Valid             at 0 range  0 ..  0;
+      D_Type            at 0 range  1 ..  1;
+      Attr_Index        at 0 range  2 ..  4;
+      Non_Secure        at 0 range  5 ..  5;
+      Data_Access       at 0 range  6 ..  7;
+      Share             at 0 range  8 ..  9;
+      Access_Flag       at 0 range 10 .. 10;
+      Non_Global        at 0 range 11 .. 11;
+      Block_Address     at 0 range 21 .. 47;
+      Contiguous        at 0 range 52 .. 52;
+      PXN_Block         at 0 range 53 .. 53;
+      XN_Block          at 0 range 54 .. 54;
+      Table_Address     at 0 range 12 .. 47;
+      PXN_Table         at 0 range 59 .. 59;
+      XN_Table          at 0 range 60 .. 60;
+      Data_Access_Table at 0 range 61 .. 62;
+      Non_Secure_Table  at 0 range 63 .. 63;
+   end record;
+
+   type Level_3_Descriptor (Valid  : Boolean  := False;
+                            D_Type : Page_Bit := Reserved) is record
+      case Valid is
+         when True =>
+            case D_Type is
+               when Page =>
+                  Attr_Index    : Attribute_Index;
+                  Non_Secure    : Boolean;
+                  Data_Access   : Access_Permission;
+                  Share         : Shareability;
+                  Access_Flag   : Boolean;
+                  Non_Global    : Boolean;
+                  Block_Address : Level_3_Output_Address;
+                  Contiguous    : Boolean;
+                  PXN_Block     : Boolean;
+                  XN_Block      : Boolean;
+               when Reserved =>
+                  null;
+            end case;
+         when False =>
+            null;
+      end case;
+   end record with
+     Size => 64;
+
+   for Level_3_Descriptor use record
+      Valid         at 0 range  0 ..  0;
+      D_Type        at 0 range  1 ..  1;
+      Attr_Index    at 0 range  2 ..  4;
+      Non_Secure    at 0 range  5 ..  5;
+      Data_Access   at 0 range  6 ..  7;
+      Share         at 0 range  8 ..  9;
+      Access_Flag   at 0 range 10 .. 10;
+      Non_Global    at 0 range 11 .. 11;
+      Block_Address at 0 range 12 .. 47;
+      Contiguous    at 0 range 52 .. 52;
+      PXN_Block     at 0 range 53 .. 53;
+      XN_Block      at 0 range 54 .. 54;
+   end record;
+
+   type Level_2_Table is array (Natural range 0 .. 511) of Level_2_Descriptor;
+
+   type Level_3_Table is array (Natural range 0 .. 511) of Level_3_Descriptor;
+
+   type Level_2_Tables is array (Natural range <>) of Level_2_Table;
+
+   type Level_3_Tables is array (Natural range <>) of Level_3_Table;
+
+   function Get_Level_1_Table return Address;
+
+   function Get_Level_1_Table return Address
+   is
+      Level_1_Table : Address;
+   begin
+      System.Machine_Code.Asm ("mrs %0, ttbr0_el1",
+                               Outputs =>  Address'Asm_Output
+                                              ("=g", Level_1_Table),
+                               Volatile => True);
+      return Level_1_Table;
+   end Get_Level_1_Table;
+
+   function Get_Address (Addr : Address)
+      return Level_2_Table_Address is
+     (Level_2_Table_Address
+        (Interfaces.Shift_Right (Interfaces.Unsigned_64 (Addr), 12)));
+
+   function Get_Address (Addr : Address)
+      return Level_3_Output_Address is
+     (Level_3_Output_Address
+        (Interfaces.Shift_Right (Interfaces.Unsigned_64 (Addr), 12)));
+
+   procedure Initialize
+   is
+      type Symbol is null record;
+      Level_1 : Level_2_Table with
+        Import,
+        Address => Get_Level_1_Table;
+      Level_2 : Level_2_Tables (0 .. 1) with
+        Import,
+        External_Name => "__mmu_ram_table_2";
+      Level_3 : Level_3_Tables (0 .. 1023) with
+        Import,
+        External_Name => "__mmu_ram_table_3";
+      Start : Address := Address'First;
+      Region_Data_Start : Symbol with
+        Import,
+        External_Name => "__region_data_start";
+      Region_Data_Start_Address : constant Address :=
+         Region_Data_Start'Address;
+   begin
+      for T of Level_3 loop
+         for I in T'Range loop
+            T (I) := Level_3_Descriptor'
+               (Valid         => True,
+                D_Type        => Page,
+                Attr_Index    => 0,
+                Non_Secure    => True,
+                Data_Access   => (if
+                                     Set_RO
+                                     and then Start < Region_Data_Start_Address
+                                  then Read_Only_EL1 else Read_Write_EL1),
+                Share         => Outer_Shareable,
+                Access_Flag   => True,
+                Non_Global    => False,
+                Block_Address => Get_Address (Start),
+                Contiguous    => False,
+                PXN_Block     => Set_NX
+                                 and Start >= Region_Data_Start_Address,
+                XN_Block      => Set_NX
+                                 and Start >= Region_Data_Start_Address);
+            Start := Start + 4096;
+         end loop;
+      end loop;
+      for I in Level_2'Range loop
+         for J in Level_2 (I)'Range loop
+            Level_2 (I)(J) := Level_2_Descriptor'
+               (Valid             => True,
+                D_Type            => Table,
+                Table_Address     =>
+                  Get_Address (Level_3 (I * 512 + J)'Address),
+                PXN_Table         => False,
+                XN_Table          => False,
+                Data_Access_Table => Read_Write_EL1,
+                Non_Secure_Table  => True);
+         end loop;
+      end loop;
+      for I in 0 .. 1 loop
+         Level_1 (I) := Level_2_Descriptor'
+            (Valid             => True,
+             D_Type            => Table,
+             Table_Address     => Get_Address (Level_2 (I)'Address),
+             PXN_Table         => False,
+             XN_Table          => False,
+             Data_Access_Table => Read_Write_EL1,
+             Non_Secure_Table  => True);
+      end loop;
+   end Initialize;
+
+end System.MMU;

--- a/src/s-mmu__zynqmp.ads
+++ b/src/s-mmu__zynqmp.ads
@@ -1,0 +1,42 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--                            S Y S T E M . M M U                           --
+--                                                                          --
+--                                 S p e c                                  --
+--                                                                          --
+--                         Copyright (C) 2021, AdaCore                      --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package System.MMU with
+   Pure,
+   No_Elaboration_Code_All
+is
+
+   procedure Initialize with
+      Export,
+      Convention    => C,
+      External_Name => "__initialize_mmu";
+
+end System.MMU;


### PR DESCRIPTION
This PR adds an MMU configuration for the zymqmp that makes the code read only and the data non-executable. Each of these features can be turned on or off individually in `mmu.adb` by setting `Set_NX` and `Set_RO` to false respectively.