### PR TITLE
Update ada-actions to the ce2021 toolchain for the community-2021 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     - run: pip3 install pycodestyle
     - name: Python stylecheck
       run: pycodestyle . --exclude=examples
-    - uses: ada-actions/toolchain@ce2020
+    - uses: ada-actions/toolchain@ce2021
       with:
         distrib: community
-    - uses: ada-actions/toolchain@ce2020
+    - uses: ada-actions/toolchain@ce2021
       with:
         distrib: community
         target: arm-elf
@@ -28,10 +28,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: ada-actions/toolchain@ce2020
+    - uses: ada-actions/toolchain@ce2021
       with:
         distrib: community
-    - uses: ada-actions/toolchain@ce2020
+    - uses: ada-actions/toolchain@ce2021
       with:
         distrib: community
         target: arm-elf


### PR DESCRIPTION
CI is currently failing on the `community-2021` branch because it's using an incompatible compiler version (it's using GNAT CE 2020). This PR updates the CI config to use the correct version for this branch, i.e. the 2021 version.