### PR TITLE
RFC: Make testbsp useful on x86_64

### DIFF
--- a/examples/test-bsp/testdata.ads
+++ b/examples/test-bsp/testdata.ads
@@ -31,6 +31,7 @@ pragma Warnings (Off);
 with System.BB.CPU_Primitives; use System.BB.CPU_Primitives;
 with System.BB.Board_Support; use System.BB.Board_Support;
 with System.BB.Parameters; use System.BB.Parameters;
+with System.BB.Time;
 pragma Warnings (On);
 package Testdata is
 
@@ -58,9 +59,9 @@ package Testdata is
    Running_Thread : access Context_Buffer;
    pragma Import (Asm, Running_Thread, "__gnat_running_thread_table");
 
-   subtype Interrupt_ID is Natural range 0 .. Number_Of_Interrupt_ID;
+   subtype Interrupt_ID is Natural range 0 .. 255;
 
-   Last_Alarm     : Timer_Interval := 0;
+   Last_Alarm     : System.BB.Time.Time := 0;
    pragma Volatile (Last_Alarm);
    subtype Alarm_Count is Natural range 0 .. 2000;
    Alarms         : Alarm_Count := 0;

--- a/examples/test-bsp/testfpu.adb
+++ b/examples/test-bsp/testfpu.adb
@@ -30,7 +30,9 @@ pragma Warnings (Off);
 with System.BB.CPU_Primitives; use System.BB.CPU_Primitives;
 pragma Warnings (On);
 
+pragma Warnings (Off);
 with Text_IO; use Text_IO;
+pragma Warnings (On);
 with Testdata; use Testdata;
 
 procedure Testfpu (Arg : access Float) is

--- a/examples/test-bsp/testhandler.adb
+++ b/examples/test-bsp/testhandler.adb
@@ -28,17 +28,19 @@
 ------------------------------------------------------------------------------
 with Testdata; use Testdata;
 pragma Warnings (Off);
+with System.BB.Time;
+with System.BB.CPU_Specific;
 with System.BB.Board_Support; use System.BB.Board_Support;
 pragma Warnings (On);
 
 with Ada.Text_IO; use Ada.Text_IO;
 
-procedure Testhandler (Vector : Vector_Id) is
+procedure Testhandler (Vector : Interrupt_ID) is
 
-   No_Interrupt : constant Interrupt_ID := Interrupt_ID (0);
+   use type System.BB.Time.Time;
 
    procedure Check (Success : Boolean; Name : String);
-   procedure Check_No_Pending;
+   --  procedure Check_No_Pending;
 
    -----------
    -- Check --
@@ -61,31 +63,30 @@ procedure Testhandler (Vector : Vector_Id) is
    -- Check_No_Pending --
    ----------------------
 
-   procedure Check_No_Pending is
-   begin
-      if Get_Interrupt_Request (Vector) /= No_Interrupt then
-         Put_Line ("  . warning: cannot verify interrupt request was cleared");
-      end if;
-   end Check_No_Pending;
+   --  procedure Check_No_Pending is
+   --  begin
+   --     if Get_Interrupt_Request (Vector) /= No_Interrupt then
+   --        Put_Line ("  . warning: cannot verify interrupt request was
+   --        cleared");
+   --     end if;
+   --  end Check_No_Pending;
 
-   Now : constant Timer_Interval := Read_Clock;
-   Int : Interrupt_ID;
+   Now : constant System.BB.Time.Time := Time.Read_Clock;
 
 begin -- Testhandler
    if Alarms = 0 then
       Check (Last_Alarm = 0, "alarm is indeed first invocation");
       Last_Alarm := Now;
-      Check (Get_Interrupt_Request (Vector) = Alarm_Interrupt_ID,
+      Check (Vector = System.BB.CPU_Specific.APIC_Timer_Vector,
         "interrupt is alarm interrupt");
-      Clear_Alarm_Interrupt;
-      pragma Debug (Check_No_Pending);
+      --  Clear_Alarm_Interrupt;
+      --  pragma Debug (Check_No_Pending);
 
    else
-      Int := Get_Interrupt_Request (Vector);
-      if Int = Alarm_Interrupt_ID then
+      if Vector = System.BB.CPU_Specific.APIC_Timer_Vector then
          Last_Alarm := Now;
          Alarms := Alarms + 1;
-         Clear_Alarm_Interrupt;
+         --  Clear_Alarm_Interrupt;
       end if;
    end if;
 end Testhandler;

--- a/examples/test-bsp/testhandler.ads
+++ b/examples/test-bsp/testhandler.ads
@@ -27,7 +27,9 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+with System.BB.Interrupts;
+
 pragma Warnings (Off);
 with System.BB.CPU_Primitives; use System.BB.CPU_Primitives;
 pragma Warnings (On);
-procedure Testhandler (Vector : Vector_Id);
+procedure Testhandler (Vector : System.BB.Interrupts.Interrupt_ID);


### PR DESCRIPTION
Hi,

I'm currently trying to hack the `testbsp` example to work on the x86_64 target. The goal is to have a good coverage of the expected BSP functionality for an upcoming x86_64 variant (Muen, see [1]).

If I run the binary via QEMU/KVM, I get a `#GP` exception, see below:

```
$ /opt/gnatpro-23.1-x86_64-elf-linux64-bin/bin/../libexec/gnatemulator/x86_64-elf/23.1/qemu-system-x86_64 -d int -gdb tcp::1234 -serial mon:stdio -nographic -no-reboot -L /opt/gnatpro-23.1-x86_64-elf-linux64-bin/bin/../share/gnatemulator/x86_64-elf/pc-bios/ -cpu SandyBridge,-check -bios - -device loader,file=bb-runtimes/examples/test-bsp/testbsp
Start TestBSP
  * check check against unexpected restart, OK
  * check initialized board, OK
  * check initialized interrupts, OK
  * check data initialization, OK
=== Clock tick duration: 1 ns
  * check clock is running, OK
  * check clock counted up at least 1 msec, OK
  * check clock counted up less than 2 msec, OK
  * check clock reading takes less than 20 usec, OK
  * check clock reading takes at least 5 ns, OK
=== Clock_Read duration: 67 ns
  * check all timer tests, OK
  . Initializing context
  * check Context_Switch to self, OK
  . Testthread (123)
  * check Context_Switch to test thread increments shared var, OK
  . Testthread got control back  after context switch
  * check repeated context switch, OK
=== Context_Switch duration: 351 ns
  * check context switches properly commit shared variables, OK
  * check all context switch tests, OK
  . Alarm_Interrupt_ID = 255
  . Priority_Of_Interrupt (Alarm_Interrupt_ID) = 255
  . Installing interrupt handler
check_exception old: 0xffffffff new 0xd
     0: v=0d e=0000 i=0 cpl=0 IP=0008:0000000000107e40 pc=0000000000107e40 SP=0010:00000000003ce898 env->regs[R_EAX]=7463656a626f2064
RAX=7463656a626f2064 RBX=0000000000123358 RCX=0000000000123698 RDX=0000000000114300
RSI=00000000000000ff RDI=00000000001af300 RBP=00000000003ce8d0 RSP=00000000003ce898
R8 =0000000000123698 R9 =0000000000000000 R10=00000000001b1c82 R11=00000000003cecc0
R12=0000000000102b37 R13=00000000003cec48 R14=0000000000123108 R15=00000000003cec48
RIP=0000000000107e40 RFL=00000002 [-------] CPL=0 II=0 A20=1 SMM=0 HLT=0
ES =0010 0000000000000000 ffffffff 00cf9300 DPL=0 DS   [-WA]
CS =0008 0000000000000000 ffffffff 00af9a00 DPL=0 CS64 [-R-]
SS =0010 0000000000000000 ffffffff 00cf9300 DPL=0 DS   [-WA]
DS =0010 0000000000000000 ffffffff 00cf9300 DPL=0 DS   [-WA]
FS =0010 0000000000000000 ffffffff 00cf9300 DPL=0 DS   [-WA]
GS =0000 00000000001b03a0 0000ffff 00009300 DPL=0 DS   [-WA]
LDT=0000 0000000000000000 0000ffff 00008200 DPL=0 LDT
TR =0018 00000000001b03a0 0000007b 00008900 DPL=0 TSS64-avl
GDT=     00000000001260e0 00000027
IDT=     00000000001af3a0 00000fff
CR0=80010011 CR2=0000000000000000 CR3=0000000000128000 CR4=00040220
DR0=0000000000000000 DR1=0000000000000000 DR2=0000000000000000 DR3=0000000000000000 
DR6=00000000ffff0ff0 DR7=0000000000000400
CCS=00000000000000ff CCD=7463656a626f2064 CCO=LOGICQ
EFER=0000000000000500
FATAL PROCESSOR EXCEPTION RAISED: General Protection ExceptionError Code:  0
Rebooting...
```

Before I invest more time, is this supposed to work, or is my testbsp port to x86 missing something? 

`0x107e40` is inside the `system__bb__threads__queues__change_priority` function, I guess the `#GP` is a result of the borked value in RAX, used as pointer. 

Thanks
reto

[1] - https://github.com/codelabs-ch/bb-runtimes

