### PR TITLE
stm32f746disco: raise clock to 216 MHz, parameterize PLLQ_Value

### DIFF
--- a/arm/cortexm.py
+++ b/arm/cortexm.py
@@ -901,46 +901,55 @@ stm32_board_configuration = {
         "STM32_Main_Clock_Frequency": "168_000_000",
         "STM32_HSE_Clock_Frequency": "8_000_000",
         "STM32_FLASH_Latency": "5",
+        "PLLQ_Value": "7",
     },
     "nucleo_f401re": {
         "STM32_Main_Clock_Frequency": "168_000_000",
         "STM32_HSE_Clock_Frequency": "8_000_000",
         "STM32_FLASH_Latency": "5",
+        "PLLQ_Value": "7",
     },
     "feather_stm32f405": {
         "STM32_Main_Clock_Frequency": "168_000_000",
         "STM32_HSE_Clock_Frequency": "12_000_000",
         "STM32_FLASH_Latency": "5",
+        "PLLQ_Value": "7",
     },
     "stm32f429disco": {
         "STM32_Main_Clock_Frequency": "180_000_000",
         "STM32_HSE_Clock_Frequency": "8_000_000",
         "STM32_FLASH_Latency": "5",
+        "PLLQ_Value": "7",
     },
     "openmv2": {
         "STM32_Main_Clock_Frequency": "180_000_000",
         "STM32_HSE_Clock_Frequency": "12_000_000",
         "STM32_FLASH_Latency": "5",
+        "PLLQ_Value": "7",
     },
     "stm32f469disco": {
         "STM32_Main_Clock_Frequency": "180_000_000",
         "STM32_HSE_Clock_Frequency": "8_000_000",
         "STM32_FLASH_Latency": "5",
+        "PLLQ_Value": "7",
     },
     "stm32f746disco": {
-        "STM32_Main_Clock_Frequency": "200_000_000",
+        "STM32_Main_Clock_Frequency": "216_000_000",
         "STM32_HSE_Clock_Frequency": "25_000_000",
-        "STM32_FLASH_Latency": "5",
+        "STM32_FLASH_Latency": "7",
+        "PLLQ_Value": "9",
     },
     "stm32756geval": {
         "STM32_Main_Clock_Frequency": "180_000_000",
         "STM32_HSE_Clock_Frequency": "25_000_000",
         "STM32_FLASH_Latency": "5",
+        "PLLQ_Value": "7",
     },
     "stm32f769disco": {
         "STM32_Main_Clock_Frequency": "200_000_000",
         "STM32_HSE_Clock_Frequency": "25_000_000",
         "STM32_FLASH_Latency": "6",
+        "PLLQ_Value": "7",
     },
 }
 

--- a/arm/stm32/s-bbbopa.ads.tmpl
+++ b/arm/stm32/s-bbbopa.ads.tmpl
@@ -43,15 +43,12 @@ package System.BB.Board_Parameters is
    --------------------
 
    Main_Clock_Frequency : constant := "${STM32_Main_Clock_Frequency}";
-   --  Optimal frequency of the system clock. Note that the STM32F411 can go
-   --  up to 200 MHz, but all other STM32F40x and STM32F41x MCUs can only do
-   --  168 MHz.
 
    HSE_Clock_Frequency : constant := "${STM32_HSE_Clock_Frequency}";
    --  Frequency of High Speed External clock.
 
    FLASH_Latency : constant := "${STM32_FLASH_Latency}";
    PLLP_Value    : constant := 2;
-   PLLQ_Value    : constant := 7;
+   PLLQ_Value    : constant := "${PLLQ_Value}";
 
 end System.BB.Board_Parameters;


### PR DESCRIPTION
Update stm32f746disco from 200 MHz to its rated maximum of 216 MHz, with the corresponding flash latency (7 WS) and PLLQ value (9, giving exactly 48 MHz USB clock from the 432 MHz VCO).

PLLQ_Value was hardcoded to 7 in the template; parameterize it so each board can specify the correct value. All existing boards retain PLLQ_Value => 7.